### PR TITLE
model-elasticsearch getByQuery error category fix

### DIFF
--- a/module/model-elasticsearch/src/source.ts
+++ b/module/model-elasticsearch/src/source.ts
@@ -460,7 +460,7 @@ export class ElasticsearchModelSource extends ModelSource {
   async getByQuery<T extends ModelCore>(cls: Class<T>, query: ModelQuery<T> = {}, failOnMany = true): Promise<T> {
     const res = await this.getAllByQuery(cls, { limit: 2, ...query });
     if (!res || res.length < 1 || (failOnMany && res.length !== 1)) {
-      throw new AppError(`Invalid number of results for find by id: ${res ? res.length : res}`, 'data');
+      throw new AppError(`Invalid number of results for find by id: ${res ? res.length : res}`, 'notfound');
     }
     return res[0] as T;
   }

--- a/module/model-elasticsearch/src/source.ts
+++ b/module/model-elasticsearch/src/source.ts
@@ -459,8 +459,10 @@ export class ElasticsearchModelSource extends ModelSource {
   }
   async getByQuery<T extends ModelCore>(cls: Class<T>, query: ModelQuery<T> = {}, failOnMany = true): Promise<T> {
     const res = await this.getAllByQuery(cls, { limit: 2, ...query });
-    if (!res || res.length < 1 || (failOnMany && res.length !== 1)) {
-      throw new AppError(`Invalid number of results for find by id: ${res ? res.length : res}`, 'notfound');
+    if (!res || res.length < 1) {
+      throw new AppError('Invalid number of results for find by id: 0', 'notfound');
+    } else if (failOnMany && res.length !== 1) {
+      throw new AppError(`Invalid number of results for find by id: ${res.length}`, 'data');
     }
     return res[0] as T;
   }

--- a/module/model-mongo/src/source.ts
+++ b/module/model-mongo/src/source.ts
@@ -175,8 +175,10 @@ export class MongoModelSource extends ModelSource {
 
   async getByQuery<T extends ModelCore>(cls: Class<T>, query: ModelQuery<T> = {}, failOnMany = true): Promise<T> {
     const res = await this.getAllByQuery(cls, { limit: 200, ...query });
-    if (!res || res.length < 1 || (failOnMany && res.length !== 1)) {
-      throw new AppError(`Invalid number of results for find by id: ${res ? res.length : res}`, 'notfound');
+    if (!res || res.length < 1) {
+      throw new AppError('Invalid number of results for find by id: 0', 'notfound');
+    } else if (failOnMany && res.length !== 1) {
+      throw new AppError(`Invalid number of results for find by id: ${res.length}`, 'data');
     }
     return res[0] as T;
   }

--- a/module/model-sql/src/source.ts
+++ b/module/model-sql/src/source.ts
@@ -250,8 +250,10 @@ export class SQLModelSource extends ModelSource {
   @Connected()
   async getByQuery<T extends ModelCore>(cls: Class<T>, query: ModelQuery<T> = {}, failOnMany = true): Promise<T> {
     const res = await this.getAllByQuery(cls, { limit: 2, ...query });
-    if (!res || res.length < 1 || (failOnMany && res.length !== 1)) {
-      throw new AppError(`Invalid number of results for find by id: ${res ? res.length : res}`, 'data');
+    if (!res || res.length < 1) {
+      throw new AppError('Invalid number of results for find by id: 0', 'notfound');
+    } else if (failOnMany && res.length !== 1) {
+      throw new AppError(`Invalid number of results for find by id: ${res.length}`, 'data');
     }
     return res[0] as T;
   }


### PR DESCRIPTION
Fixed model-elasticsearch ElasticsearchModelSource getByQuery no results error category, so that it can be properly handled by auth PrincipalProvider resolveOrCreatePrincipal.