### PR TITLE
Elasticsearch Index Name regex

### DIFF
--- a/module/model-elasticsearch/src/util.ts
+++ b/module/model-elasticsearch/src/util.ts
@@ -201,7 +201,7 @@ export class ElasticsearchUtil {
       if (o[x] === undefined || o[x] === null) {
         ops.push(`ctx._source.${path}${path ? '.' : ''}remove("${x}")`);
       } else if (Util.isPrimitive(o[x]) || Array.isArray(o[x])) {
-        const param = prop.replace(/[^a-z0-9_$]/g, '_');
+        const param = prop.toLowerCase().replace(/[^a-z0-9_$]/g, '_');
         ops.push(`ctx._source.${prop} = params.${param}`);
         out.params[param] = o[x];
       } else {

--- a/module/model-elasticsearch/src/util.ts
+++ b/module/model-elasticsearch/src/util.ts
@@ -201,7 +201,7 @@ export class ElasticsearchUtil {
       if (o[x] === undefined || o[x] === null) {
         ops.push(`ctx._source.${path}${path ? '.' : ''}remove("${x}")`);
       } else if (Util.isPrimitive(o[x]) || Array.isArray(o[x])) {
-        const param = prop.replace(/[^A-Za-z_$]/g, '_');
+        const param = prop.replace(/[^a-z0-9_$]/g, '_');
         ops.push(`ctx._source.${prop} = params.${param}`);
         out.params[param] = o[x];
       } else {


### PR DESCRIPTION
Ran into error where index names with numbers (street1, street2) were being regexed causing later errors updating partial for an address (`ctx._source.address.street1 = params.address_street_`).

Not 100% sure of the regex purpose but it appears to be sanitizing invalid characters. Given that I also changed the regex to replace capital letters since they are invalid in index names. ( Valid index names: https://discuss.elastic.co/t/index-name-type-name-and-field-name-rules/133039/2 ) I feel like this could be improved to better handle index names, but not sure how to best handle that so I kept my change simple. For example, the replace character _ is also not allowed to start an index name. There are also valid characters that would be overwritten by this regex and other considerations like max length.