### PR TITLE
1.0.0 rest logging suppression

### DIFF
--- a/module/rest/index.ts
+++ b/module/rest/index.ts
@@ -16,6 +16,8 @@ export * from './src/interceptor/cors';
 export * from './src/interceptor/cookies';
 export * from './src/interceptor/get-cache';
 export * from './src/interceptor/interceptor';
+export * from './src/interceptor/logging';
+export * from './src/interceptor/serialize';
 export * from './src/types';
 export * from './src/util/mime';
 export * from './src/util/param';

--- a/module/rest/src/config.ts
+++ b/module/rest/src/config.ts
@@ -1,11 +1,9 @@
 import * as os from 'os';
-import * as cookies from 'cookies';
 
 import { Config } from '@travetto/config';
 import { Env, AppError, ResourceManager } from '@travetto/base';
 
 import { SSLUtil } from './util/ssl';
-import { Method } from './types';
 
 @Config('rest')
 export class RestConfig {
@@ -19,30 +17,12 @@ export class RestConfig {
 
   defaultMessage = true;
 
-  cookie: cookies.SetOption & { active: boolean, signed: boolean, keys: string[] } = {
-    active: true,
-    signed: true,
-    httpOnly: true,
-    sameSite: 'lax',
-    keys: ['default-insecure']
-  };
-
   ssl: {
     active?: boolean,
     keys?: {
       cert: string,
       key: string
     }
-  } = {
-      active: false
-    };
-
-  cors: {
-    active: boolean;
-    origins?: string[],
-    methods?: Method[],
-    headers?: string[],
-    credentials?: boolean
   } = {
       active: false
     };
@@ -54,14 +34,8 @@ export class RestConfig {
 
       this.bindAddress = useIPv4 ? '0.0.0.0' : '::';
     }
-    if (this.cookie.secure === undefined) {
-      this.cookie.secure = this.ssl.active;
-    }
     if (this.baseUrl === undefined) {
       this.baseUrl = `http${this.ssl.active ? 's' : ''}://${this.hostname}${[80, 443].includes(this.port) ? '' : `:${this.port}`}`;
-    }
-    if (this.cookie.domain === undefined) {
-      this.cookie.domain = this.hostname;
     }
   }
 

--- a/module/rest/src/interceptor/cookies.ts
+++ b/module/rest/src/interceptor/cookies.ts
@@ -2,12 +2,24 @@ import * as cookies from 'cookies';
 import { ServerResponse, IncomingMessage } from 'http';
 
 import { Injectable, Inject } from '@travetto/di';
+import { Config } from '@travetto/config';
 
 import { RouteConfig, Request, Response } from '../types';
 import { RestConfig } from '../config';
 import { RestInterceptor } from './interceptor';
 import { CorsInterceptor } from './cors';
 import { GetCacheInterceptor } from './get-cache';
+
+@Config('rest.cookie')
+export class RestCookieConfig implements cookies.SetOption {
+  active = true;
+  signed = true;
+  httpOnly = true;
+  sameSite: cookies.SetOption['sameSite'] | 'lax' = 'lax';
+  keys = ['default-insecure'];
+  secure?: boolean;
+  domain?: string;
+}
 
 @Injectable()
 export class CookiesInterceptor extends RestInterceptor {
@@ -16,10 +28,22 @@ export class CookiesInterceptor extends RestInterceptor {
   before = GetCacheInterceptor;
 
   @Inject()
-  config: RestConfig;
+  cookieConfig: RestCookieConfig;
+
+  @Inject()
+  restConfig: RestConfig;
 
   postConstruct() {
-    const self = this.config.cookie;
+    const self = this.cookieConfig;
+
+    if (this.cookieConfig.secure === undefined) {
+      this.cookieConfig.secure = this.restConfig.ssl.active;
+    }
+
+    if (this.cookieConfig.domain === undefined) {
+      this.cookieConfig.domain = this.restConfig.hostname;
+    }
+
 
     // Patch all cookies to default to the cookie values
     const set = cookies.prototype.set;
@@ -37,7 +61,7 @@ export class CookiesInterceptor extends RestInterceptor {
   }
 
   applies(route: RouteConfig) {
-    return this.config.cookie.active;
+    return this.cookieConfig.active;
   }
 
   intercept(req: Request, res: Response) {
@@ -45,7 +69,7 @@ export class CookiesInterceptor extends RestInterceptor {
       req.cookies = res.cookies = new cookies(
         req as any as IncomingMessage,
         res as any as ServerResponse,
-        this.config.cookie
+        this.cookieConfig
       );
     }
   }

--- a/module/rest/src/interceptor/cors.ts
+++ b/module/rest/src/interceptor/cors.ts
@@ -1,14 +1,23 @@
+import { Config } from '@travetto/config';
 import { Injectable, Inject } from '@travetto/di';
 
-import { Request, Response, RouteConfig } from '../types';
+import { Request, Response, RouteConfig, Method } from '../types';
 import { RestInterceptor } from './interceptor';
-import { RestConfig } from '../config';
+
+@Config('rest.cors')
+class RestCorsConfig {
+  active: boolean = false;
+  origins?: string[];
+  methods?: Method[];
+  headers?: string[];
+  credentials?: boolean
+}
 
 @Injectable()
 export class CorsInterceptor extends RestInterceptor {
 
   @Inject()
-  restConfig: RestConfig;
+  corsConfig: RestCorsConfig;
 
   origins: Set<string>;
   methods: string;
@@ -16,14 +25,14 @@ export class CorsInterceptor extends RestInterceptor {
   credentials: boolean = false;
 
   postConstruct() {
-    this.origins = new Set(this.restConfig.cors.origins || []);
-    this.methods = (this.restConfig.cors.methods || ['PUT', 'POST', 'GET', 'DELETE', 'PATCH']).join(',');
-    this.headers = (this.restConfig.cors.headers || []).join(',');
-    this.credentials = !!this.restConfig.cors.credentials;
+    this.origins = new Set(this.corsConfig.origins || []);
+    this.methods = (this.corsConfig.methods || ['PUT', 'POST', 'GET', 'DELETE', 'PATCH']).join(',');
+    this.headers = (this.corsConfig.headers || []).join(',');
+    this.credentials = !!this.corsConfig.credentials;
   }
 
   public applies?(route: RouteConfig) {
-    return this.restConfig.cors && this.restConfig.cors.active;
+    return this.corsConfig && this.corsConfig.active;
   }
 
   intercept(req: Request, res: Response) {

--- a/module/rest/src/interceptor/interceptor.ts
+++ b/module/rest/src/interceptor/interceptor.ts
@@ -7,5 +7,5 @@ export abstract class RestInterceptor {
   public before?: Class<RestInterceptor>[] | Set<Class<RestInterceptor>> | Class<RestInterceptor>;
   public applies?(route: RouteConfig): boolean;
 
-  abstract intercept(req: Request, res: Response, next?: () => Promise<any>): Promise<void> | void;
+  abstract intercept(req: Request, res: Response, next?: () => Promise<any>): Promise<any> | void;
 }

--- a/module/rest/src/interceptor/logging.ts
+++ b/module/rest/src/interceptor/logging.ts
@@ -1,0 +1,73 @@
+import { Injectable, Inject } from '@travetto/di';
+import { Config } from '@travetto/config';
+
+import { Request, Response, RouteConfig } from '../types';
+import { RestInterceptor } from './interceptor';
+import { CorsInterceptor } from './cors';
+
+@Config('rest.logRoutes')
+export class RestLogRoutesConfig {
+  allow: (string | RegExp)[] = [];
+  deny: (string | RegExp)[] = [];
+}
+
+@Injectable()
+export class LoggingInterceptor extends RestInterceptor {
+
+  static matchRoute(route: RouteConfig, paths: (string | RegExp)[]) {
+    return paths.some(path => {
+      if (typeof path === 'string') {
+        if (typeof route.path === 'string') {
+          return route.path === path;
+        } else {
+          return route.path.test(path);
+        }
+      } else {
+        if (route.path instanceof RegExp) {
+          return route.path.source === path.source;
+        } else {
+          return path.test(route.path);
+        }
+      }
+    });
+  }
+
+  before = CorsInterceptor;
+
+  @Inject()
+  logConfig: RestLogRoutesConfig;
+
+  public applies?(route: RouteConfig) {
+    return this.logConfig.deny.length ?
+      !LoggingInterceptor.matchRoute(route, this.logConfig.deny) :
+      (this.logConfig.allow.length ?
+        LoggingInterceptor.matchRoute(route, this.logConfig.allow) : true);
+  }
+
+  async intercept(req: Request, res: Response, next: () => Promise<any>) {
+    const start = Date.now();
+
+    try {
+      return await next();
+    } finally {
+      const duration = Date.now() - start;
+
+      const reqLog = {
+        meta: {
+          method: req.method,
+          path: req.baseUrl ? `${req.baseUrl}${req.path}`.replace(/\/+/, '/') : req.path,
+          query: req.query,
+          params: req.params,
+          statusCode: res.statusCode,
+          duration
+        }
+      };
+
+      if (reqLog.meta.statusCode < 400) {
+        console.info(`Request`, reqLog);
+      } else {
+        console.error(`Request`, reqLog);
+      }
+    }
+  }
+}

--- a/module/rest/src/interceptor/serialize.ts
+++ b/module/rest/src/interceptor/serialize.ts
@@ -1,0 +1,55 @@
+import { AppError } from '@travetto/base';
+import { Injectable } from '@travetto/di';
+
+import { RestInterceptor } from './interceptor';
+import { LoggingInterceptor } from './logging';
+
+import { MimeType } from '../util/mime';
+import { Response, Request } from '../types';
+import { isRenderable } from '../response/renderable';
+
+@Injectable()
+export class SerializeInterceptor extends RestInterceptor {
+
+  before = LoggingInterceptor;
+
+  static setContentTypeIfUndefined(res: Response, type: string) {
+    if (!res.getHeader('Content-Type')) {
+      res.setHeader('Content-Type', type);
+    }
+  }
+
+  static async sendOutput(req: Request, res: Response, output: any) {
+    if (!res.headersSent) {
+      if (output) {
+        if (isRenderable(output)) {
+          await output.render(res);
+        } else if (typeof output === 'string') {
+          this.setContentTypeIfUndefined(res, MimeType.TEXT);
+          res.send(output);
+        } else if ('toJSON' in output) {
+          this.setContentTypeIfUndefined(res, MimeType.JSON);
+          res.send((output as any).toJSON());
+        } else {
+          this.setContentTypeIfUndefined(res, MimeType.JSON);
+          res.send(JSON.stringify(output as any, undefined, 'pretty' in req.query ? 2 : 0));
+        }
+      } else {
+        res.status(201);
+        res.send('');
+      }
+    }
+  }
+
+  async intercept(req: Request, res: Response, next: (() => Promise<any>)): Promise<any> {
+    try {
+      const output = await next();
+      await SerializeInterceptor.sendOutput(req, res, output);
+    } catch (error) {
+      if (!(error instanceof Error)) {  // Ensure we always throw "Errors"
+        error = new AppError(error.message || 'Unexpected error', 'general', error);
+      }
+      await SerializeInterceptor.sendOutput(req, res, error);
+    }
+  }
+}

--- a/module/rest/src/util/route.ts
+++ b/module/rest/src/util/route.ts
@@ -10,25 +10,6 @@ import { ParamUtil } from './param';
 
 export class RouteUtil {
 
-  static logRequest(req: Request, res: Response, duration: number) {
-    const reqLog = {
-      meta: {
-        method: req.method,
-        path: req.baseUrl ? `${req.baseUrl}${req.path}`.replace(/\/+/, '/') : req.path,
-        query: req.query,
-        params: req.params,
-        statusCode: res.statusCode,
-        duration
-      }
-    };
-
-    if (reqLog.meta.statusCode < 400) {
-      console.info(`Request`, reqLog);
-    } else {
-      console.error(`Request`, reqLog);
-    }
-  }
-
   static async sendOutput(req: Request, res: Response, output: any, headers?: HeaderMap) {
     if (!res.headersSent) {
       if (headers) {
@@ -77,7 +58,6 @@ export class RouteUtil {
   }
 
   static async _routeHandler(filterChain: Filter, headers: HeaderMap, req: Request, res: Response) {
-    const start = Date.now();
     try {
       const output = await filterChain(req, res);
       await this.sendOutput(req, res, output, headers);
@@ -86,8 +66,6 @@ export class RouteUtil {
         error = new AppError(error.message || 'Unexpected error', 'general', error);
       }
       await this.sendOutput(req, res, error);
-    } finally {
-      this.logRequest(req, res, Date.now() - start);
     }
   }
 

--- a/module/rest/src/util/route.ts
+++ b/module/rest/src/util/route.ts
@@ -1,48 +1,10 @@
-import { AppError } from '@travetto/base';
-
-import { HeaderMap, Request, Response, Filter, RouteConfig } from '../types';
+import { Request, Response, Filter, RouteConfig } from '../types';
 import { EndpointConfig, ControllerConfig } from '../registry/types';
-import { isRenderable } from '../response/renderable';
 import { RestInterceptor } from '../interceptor/interceptor';
 
-import { MimeType } from './mime';
 import { ParamUtil } from './param';
 
 export class RouteUtil {
-
-  static async sendOutput(req: Request, res: Response, output: any, headers?: HeaderMap) {
-    if (!res.headersSent) {
-      if (headers) {
-        for (const [h, v] of Object.entries(headers)) {
-          res.setHeader(h, typeof v === 'string' ? v : v());
-        }
-      }
-
-      if (output) {
-        if (isRenderable(output)) {
-          await output.render(res);
-        } else if (typeof output === 'string') {
-          if (!res.getHeader('Content-Type')) {
-            res.setHeader('Content-Type', MimeType.TEXT);
-          }
-          res.send(output);
-        } else if ('toJSON' in output) {
-          if (!res.getHeader('Content-Type')) {
-            res.setHeader('Content-Type', MimeType.JSON);
-          }
-          res.send((output as any).toJSON());
-        } else {
-          if (!res.getHeader('Content-Type')) {
-            res.setHeader('Content-Type', MimeType.JSON);
-          }
-          res.send(JSON.stringify(output as any, undefined, 'pretty' in req.query ? 2 : 0));
-        }
-      } else {
-        res.status(201);
-        res.send('');
-      }
-    }
-  }
 
   static createFilterChain(filters: (Filter | RestInterceptor['intercept'])[]): Filter<Promise<any>> {
     return function filterChain(req: Request, res: Response, idx: number = filters.length - 1): Promise<any> | any {
@@ -55,18 +17,6 @@ export class RouteUtil {
         return out && out.then ? out.then(next) : next();
       }
     };
-  }
-
-  static async _routeHandler(filterChain: Filter, headers: HeaderMap, req: Request, res: Response) {
-    try {
-      const output = await filterChain(req, res);
-      await this.sendOutput(req, res, output, headers);
-    } catch (error) {
-      if (!(error instanceof Error)) {  // Ensure we always throw "Errors"
-        error = new AppError(error.message || 'Unexpected error', 'general', error);
-      }
-      await this.sendOutput(req, res, error);
-    }
   }
 
   static createRouteHandler(
@@ -90,14 +40,22 @@ export class RouteUtil {
       ...('headers' in route ? route.headers : {})
     };
 
-    const filterChain = this.createFilterChain([
+    const filterChain = [
       ...interceptors
         .filter(x => x.applies ? x.applies(route) : true)
         .map(x => x.intercept.bind(x)),
       ...filters,
       handlerBound
-    ].reverse());
+    ];
 
-    return this._routeHandler.bind(this, filterChain, headers);
+    if (headers && Object.keys(headers).length > 1) {
+      filterChain.push((_: Request, res: Response) => {
+        for (const [h, v] of Object.entries(headers)) {
+          res.setHeader(h, typeof v === 'string' ? v : v());
+        }
+      });
+    }
+
+    return this.createFilterChain(filterChain.reverse());
   }
 }

--- a/module/schema/test/rest.ts
+++ b/module/schema/test/rest.ts
@@ -50,6 +50,7 @@ export class RestTest {
       result: undefined as any,
       statusCode: 201,
       setHeader() { },
+      getHeader(field: String) { return ''; },
       send(val: any) {
         this.result = JSON.parse(val);
       },
@@ -86,6 +87,7 @@ export class RestTest {
       result: undefined as any,
       statusCode: 201,
       setHeader() { },
+      getHeader(field: String) { return ''; },
       send(val: any) {
         this.result = JSON.parse(val);
       },

--- a/module/schema/test/rest.ts
+++ b/module/schema/test/rest.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { Suite, Test, BeforeAll } from '@travetto/test';
-import { Controller, Post, ControllerRegistry, Method, RouteUtil, Get } from '@travetto/rest';
+import { Controller, Post, ControllerRegistry, Method, RouteUtil, Get, SerializeInterceptor } from '@travetto/rest';
 
 import { SchemaBody, SchemaQuery } from '../extension/rest';
 
@@ -44,7 +44,7 @@ export class RestTest {
   async verifyBody() {
     const ep = RestTest.getEndpoint('/user', 'post');
 
-    const handler = RouteUtil.createRouteHandler([], ep);
+    const handler = RouteUtil.createRouteHandler([new SerializeInterceptor()], ep);
 
     const res = {
       result: undefined as any,
@@ -81,7 +81,7 @@ export class RestTest {
   async verifyQuery() {
     const ep = RestTest.getEndpoint('/user', 'get');
 
-    const handler = RouteUtil.createRouteHandler([], ep);
+    const handler = RouteUtil.createRouteHandler([new SerializeInterceptor()], ep);
 
     const res = {
       result: undefined as any,


### PR DESCRIPTION
...
Allow for logging suppression as a allow/deny pattern.  To block the global route handler from logging, you would use `rest.logRoutes.deny=['*']`. 

Thoughts?