### PR TITLE
feat(repo): support OTP token prompt and login check for publishing

### DIFF
--- a/global-test/pack_app/test/pack.ts
+++ b/global-test/pack_app/test/pack.ts
@@ -12,19 +12,19 @@ class PackAppSuite {
     const tag = `tag-${Math.random()}`.replace(/[0][.]/, '');
     const imageName = 'travetto-test_pack_app';
     assert(Runtime.mainSourcePath.endsWith('pack_app'));
-    const proc = ExecUtil.spawnPackageCommand('trv', ['pack:docker', '-dt', tag, 'run:double'], { cwd: Runtime.mainSourcePath });
+    const process = ExecUtil.spawnPackageCommand('trv', ['pack:docker', '-dt', tag, 'run:double'], { cwd: Runtime.mainSourcePath });
 
-    const state = await ExecUtil.getResult(proc, { catch: true });
+    const state = await ExecUtil.getResult(process, { catch: true });
     console.log(state.stderr);
     assert(state.valid);
 
-    const proc2 = spawn('docker', ['run', '--rm', `${imageName}:${tag}`, '30']);
-    const state2 = await ExecUtil.getResult(proc2);
+    const process2 = spawn('docker', ['run', '--rm', `${imageName}:${tag}`, '30']);
+    const state2 = await ExecUtil.getResult(process2);
     assert(state2.stderr === '');
     assert(state2.code === 0);
 
-    const proc3 = spawn('docker', ['image', 'rm', '--force', `${imageName}:${tag}`]);
-    await ExecUtil.getResult(proc3);
+    const process3 = spawn('docker', ['image', 'rm', '--force', `${imageName}:${tag}`]);
+    await ExecUtil.getResult(process3);
 
     assert(state2.stdout.includes('Result: 60'));
     assert(/Result: 60/.test(state2.stdout));

--- a/module/repo/support/bin/exec.ts
+++ b/module/repo/support/bin/exec.ts
@@ -17,6 +17,7 @@ type ModuleRunConfig = {
   progressMessage?: (module: IndexedModule | undefined) => string;
   filter?: (module: IndexedModule) => boolean | Promise<boolean>;
   progressListKey?: (module: IndexedModule) => string;
+  isSuccess?: (result: ExecutionResult) => boolean;
   showProgressList?: boolean;
   workerCount?: number;
   prefixOutput?: boolean;
@@ -121,7 +122,7 @@ export class RepoExecUtil {
       max: workerCount,
       min: workerCount,
       total: modules.length,
-      isSuccess: result => result.valid,
+      isSuccess: config.isSuccess ?? ((result: ExecutionResult): boolean => result.valid),
     });
 
     if (config.progressMessage && stdoutTerm.interactive) {
@@ -131,9 +132,8 @@ export class RepoExecUtil {
       await stdoutTerm.streamToBottom(
         Util.mapAsyncIterable(
           Util.mapAsyncIterable(work, (event): ProgressEvent<string> => {
-            const { progress, failures, total } = event.progress;
-            const message = config.progressMessage?.(modulesToRun[progress]) ?? ` (${failures} failed)`;
-            return { idx: progress, value: message, total };
+            const message = config.progressMessage?.(modulesToRun[event.progress.completed]) ?? 'Completed %completed/%total (%failed failed)';
+            return { ...event.progress, value: message };
           }),
           TerminalUtil.progressBarUpdater(stdoutTerm, { withWaiting: true }))
       );

--- a/module/repo/support/bin/exec.ts
+++ b/module/repo/support/bin/exec.ts
@@ -1,9 +1,9 @@
 import type { ChildProcess } from 'node:child_process';
 
-import { type ExecutionResult, Env, Util, ExecUtil, castTo, CodecUtil, Runtime, RuntimeIndex, AsyncQueue } from '@travetto/runtime';
+import { type ExecutionResult, Env, Util, ExecUtil, CodecUtil, Runtime, RuntimeIndex, AsyncQueue } from '@travetto/runtime';
 import { CliModuleUtil } from '@travetto/cli';
 import type { IndexedModule } from '@travetto/manifest';
-import { StyleUtil, Terminal, TerminalUtil } from '@travetto/terminal';
+import { StyleUtil, Terminal, TerminalUtil, type ProgressEvent } from '@travetto/terminal';
 import { WorkPool } from '@travetto/worker';
 
 const COLORS = ([...[
@@ -13,10 +13,9 @@ const COLORS = ([...[
   '#c6c6c6', '#d0d0d0', '#dadada', '#e4e4e4', '#eeeeee'
 ] as const]).toSorted(() => Math.random() < .5 ? -1 : 1).map(color => StyleUtil.getStyle(color));
 
-type ModuleRunConfig<T = ExecutionResult<string>> = {
+type ModuleRunConfig = {
   progressMessage?: (module: IndexedModule | undefined) => string;
   filter?: (module: IndexedModule) => boolean | Promise<boolean>;
-  transformResult?: (module: IndexedModule, result: ExecutionResult<string>) => T;
   progressListKey?: (module: IndexedModule) => string;
   showProgressList?: boolean;
   workerCount?: number;
@@ -48,20 +47,19 @@ export class RepoExecUtil {
   /**
    * Run on all modules
    */
-  static async execOnModules<T = ExecutionResult>(
+  static async execOnModules(
     mode: 'all' | 'workspace' | 'changed',
     operation: (module: IndexedModule) => ChildProcess,
-    config: ModuleRunConfig<T> = {}
-  ): Promise<Map<IndexedModule, T>> {
+    config: ModuleRunConfig = {}
+  ): Promise<Map<IndexedModule, ExecutionResult>> {
 
     config.showStdout = config.showStdout ?? (Env.DEBUG.isSet && !Env.DEBUG.isFalse);
     config.showStderr = config.showStderr ?? true;
-    const transform = config.transformResult ?? ((module, result): T => castTo(result));
 
     const workerCount = config.workerCount ?? WorkPool.DEFAULT_SIZE;
 
     const modules = await CliModuleUtil.findModules(mode);
-    const results = new Map<IndexedModule, T>();
+    const results = new Map<IndexedModule, ExecutionResult>();
     const processes = new Map<IndexedModule, ChildProcess>();
 
     const prefixes = config.prefixOutput !== false ? this.#buildPrefixes(modules) : {};
@@ -85,7 +83,7 @@ export class RepoExecUtil {
     ) : modules)
       .filter((module): module is IndexedModule => !!module);
 
-    const work = WorkPool.runStreamProgress(async (module) => {
+    const work = WorkPool.runStream<IndexedModule, ExecutionResult>(async (module) => {
       try {
         const prefix = prefixes[module.sourceFolder] ?? '';
         const listKey = config.progressListKey?.(module) ?? ` * ${module.name}`;
@@ -107,7 +105,6 @@ export class RepoExecUtil {
         }
 
         const result = await ExecUtil.getResult(subProcess, { catch: true });
-        const output = transform(module, result);
 
         active.delete(listKey);
         [...active].sort().forEach((text, idx) => activeItems.add({ idx, text }));
@@ -115,18 +112,31 @@ export class RepoExecUtil {
           activeItems.add({ idx: j, text: '' }); // Force update to remove item if needed
         }
 
-        results.set(module, output);
-        return config.progressMessage?.(module) ?? module.name;
+        results.set(module, result);
+        return result;
       } finally {
         processes.get(module!)?.kill();
       }
-    }, modulesToRun, modules.length, { max: workerCount, min: workerCount });
+    }, modulesToRun, {
+      max: workerCount,
+      min: workerCount,
+      total: modules.length,
+      isSuccess: result => result.valid,
+    });
 
     if (config.progressMessage && stdoutTerm.interactive) {
       if (config.showProgressList) {
         stdoutTerm.streamList(activeItems);
       }
-      await stdoutTerm.streamToBottom(Util.mapAsyncIterable(work, TerminalUtil.progressBarUpdater(stdoutTerm, { withWaiting: true })));
+      await stdoutTerm.streamToBottom(
+        Util.mapAsyncIterable(
+          Util.mapAsyncIterable(work, (event): ProgressEvent<string> => {
+            const { progress, failures, total } = event.progress;
+            const message = config.progressMessage?.(modulesToRun[progress]) ?? ` (${failures} failed)`;
+            return { idx: progress, value: message, total };
+          }),
+          TerminalUtil.progressBarUpdater(stdoutTerm, { withWaiting: true }))
+      );
 
       if (stdoutTerm.interactive && config.showProgressList) {
         stdoutTerm.writer.changePosition({ y: -listHeader.length, x: 0 }).storePosition().writeLines(Array(listHeader.length).fill('')).restoreOnCommit().commit();

--- a/module/repo/support/bin/package-manager.ts
+++ b/module/repo/support/bin/package-manager.ts
@@ -15,6 +15,19 @@ export type SemverLevel = 'minor' | 'patch' | 'major' | 'prerelease' | 'premajor
 export class PackageManager {
 
   /**
+   * Check if npm login is needed
+   */
+  static async needsLogin(): Promise<boolean> {
+    try {
+      const result = await ExecUtil.getResult(spawn('npm', ['whoami']), { catch: true });
+      return !result.valid;
+    } catch {
+      // Ignore errors checking for login profile
+    }
+    return false;
+  }
+
+  /**
    * Check if OTP is needed for publishing
    */
   static async needsOtp(): Promise<boolean> {

--- a/module/repo/support/bin/package-manager.ts
+++ b/module/repo/support/bin/package-manager.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs/promises';
 
-import { JSONUtil, type ExecutionResult, Runtime, ExecUtil, RuntimeError, CodecUtil } from '@travetto/runtime';
+import { JSONUtil, type ExecutionResult, Runtime, ExecUtil } from '@travetto/runtime';
 import { type IndexedModule, type Package, PackageUtil } from '@travetto/manifest';
 import { CliModuleUtil } from '@travetto/cli';
 import { TerminalUtil } from '@travetto/terminal';
@@ -18,13 +18,8 @@ export class PackageManager {
    * Check if npm login is needed
    */
   static async needsLogin(): Promise<boolean> {
-    try {
-      const result = await ExecUtil.getResult(spawn('npm', ['whoami']), { catch: true });
-      return !result.valid;
-    } catch {
-      // Ignore errors checking for login profile
-    }
-    return false;
+    const result = await ExecUtil.getResult(spawn('npm', ['whoami']), { catch: true });
+    return !result.valid;
   }
 
   /**
@@ -47,30 +42,25 @@ export class PackageManager {
    * Request an OTP token if required
    */
   static async requestOtp(): Promise<string | undefined> {
-    let otp: string | undefined;
     if (TerminalUtil.isInteractive()) {
       console.log([
         'OTP token is required for publishing. Please provide an OTP token to proceed with publishing.',
         'This value will not be stored, and is only used for the current publish operation.'
       ].join(' '));
-      otp = await TerminalUtil.prompt('Enter OTP token: ');
+      return await TerminalUtil.prompt('Enter OTP token: ');
     }
-    if (!otp) {
-      throw new RuntimeError('OTP token is required for publishing, but was not provided.');
-    }
-    return otp;
   }
 
   /**
    * Classify publish error from execution result
    */
   static classifyPublishError(result: ExecutionResult): string {
-    const errorText = CodecUtil.toUTF8String(result.stderr || result.stdout || '').trim();
+    const errorText = ExecUtil.toString(result, 'any');
 
     if (/EOTP|one-time password|two-factor|OTP/i.test(errorText)) {
       return 'Two-factor authentication (OTP) failed or was missing.';
     }
-    if (/EPUBLISHCONFLICT|E403.*previously published|cannot publish over/i.test(errorText)) {
+    if (/EPUBLISHCONFLICT|E403(.){,100}previously published|cannot publish over/i.test(errorText)) {
       return 'Version conflict: This version has already been published to the registry.';
     }
     if (/ENEEDAUTH|E401|login|unauthorized/i.test(errorText)) {
@@ -100,12 +90,12 @@ export class PackageManager {
    * Validate published result
    */
   static validatePublishedResult(result: ExecutionResult): boolean {
-    const stderr = CodecUtil.toUTF8String(result.stderr || '').trim();
+    const stderr = ExecUtil.toString(result, 'stderr');
     if (!result.valid && !stderr.includes('E404')) {
       throw new Error(stderr);
     }
 
-    const stdout = CodecUtil.toUTF8String(result.stdout || '').trim();
+    const stdout = ExecUtil.toString(result, 'stdout');
     type PackageInfo = { dist?: { integrity?: string } };
     let parsed = JSONUtil.fromUTF8<PackageInfo | { data: PackageInfo }>(stdout || '{}');
     if ('data' in parsed) { // Yarn support

--- a/module/repo/support/bin/package-manager.ts
+++ b/module/repo/support/bin/package-manager.ts
@@ -2,9 +2,10 @@ import path from 'node:path';
 import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs/promises';
 
-import { JSONUtil, type ExecutionResult, Runtime } from '@travetto/runtime';
+import { JSONUtil, type ExecutionResult, Runtime, ExecUtil, RuntimeError, CodecUtil } from '@travetto/runtime';
 import { type IndexedModule, type Package, PackageUtil } from '@travetto/manifest';
 import { CliModuleUtil } from '@travetto/cli';
+import { TerminalUtil } from '@travetto/terminal';
 
 export type SemverLevel = 'minor' | 'patch' | 'major' | 'prerelease' | 'premajor' | 'preminor' | 'prepatch';
 
@@ -12,6 +13,62 @@ export type SemverLevel = 'minor' | 'patch' | 'major' | 'prerelease' | 'premajor
  * Utilities for working with package managers
  */
 export class PackageManager {
+
+  /**
+   * Check if OTP is needed for publishing
+   */
+  static async needsOtp(): Promise<boolean> {
+    try {
+      const result = await ExecUtil.getResult(spawn('npm', ['profile', 'get', '--json']), { catch: true });
+      if (result.valid) {
+        const info = JSONUtil.fromUTF8<{ tfa?: { mode?: string } }>(result.stdout);
+        return !!info?.tfa?.mode;
+      }
+    } catch {
+      // Ignore errors checking for OTP profile
+    }
+    return false;
+  }
+
+  /**
+   * Request an OTP token if required
+   */
+  static async requestOtp(): Promise<string | undefined> {
+    let otp: string | undefined;
+    if (TerminalUtil.isInteractive()) {
+      console.log([
+        'OTP token is required for publishing. Please provide an OTP token to proceed with publishing.',
+        'This value will not be stored, and is only used for the current publish operation.'
+      ].join(' '));
+      otp = await TerminalUtil.prompt('Enter OTP token: ');
+    }
+    if (!otp) {
+      throw new RuntimeError('OTP token is required for publishing, but was not provided.');
+    }
+    return otp;
+  }
+
+  /**
+   * Classify publish error from execution result
+   */
+  static classifyPublishError(result: ExecutionResult): string {
+    const errorText = CodecUtil.toUTF8String(result.stderr || result.stdout || '').trim();
+
+    if (/EOTP|one-time password|two-factor|OTP/i.test(errorText)) {
+      return 'Two-factor authentication (OTP) failed or was missing.';
+    }
+    if (/EPUBLISHCONFLICT|E403.*previously published|cannot publish over/i.test(errorText)) {
+      return 'Version conflict: This version has already been published to the registry.';
+    }
+    if (/ENEEDAUTH|E401|login|unauthorized/i.test(errorText)) {
+      return 'Authentication failed: Please log in or check your registry credentials.';
+    }
+    if (/E403|permission|not allowed/i.test(errorText)) {
+      return 'Permission denied: You do not have access to publish this package.';
+    }
+
+    return errorText || 'Unknown publishing error.';
+  }
 
   /**
    * Is a module already published
@@ -29,13 +86,15 @@ export class PackageManager {
   /**
    * Validate published result
    */
-  static validatePublishedResult(result: ExecutionResult<string>): boolean {
-    if (!result.valid && !result.stderr.includes('E404')) {
-      throw new Error(result.stderr);
+  static validatePublishedResult(result: ExecutionResult): boolean {
+    const stderr = CodecUtil.toUTF8String(result.stderr || '').trim();
+    if (!result.valid && !stderr.includes('E404')) {
+      throw new Error(stderr);
     }
 
+    const stdout = CodecUtil.toUTF8String(result.stdout || '').trim();
     type PackageInfo = { dist?: { integrity?: string } };
-    let parsed = JSONUtil.fromUTF8<PackageInfo | { data: PackageInfo }>(result.stdout || '{}');
+    let parsed = JSONUtil.fromUTF8<PackageInfo | { data: PackageInfo }>(stdout || '{}');
     if ('data' in parsed) { // Yarn support
       parsed = parsed.data;
     }
@@ -72,7 +131,7 @@ export class PackageManager {
   /**
    * Publish a module
    */
-  static publish(module: IndexedModule, dryRun: boolean | undefined): ChildProcess {
+  static publish(module: IndexedModule, dryRun: boolean | undefined, otp?: string): ChildProcess {
     if (dryRun) {
       return this.dryRunPackaging(module);
     }
@@ -82,7 +141,7 @@ export class PackageManager {
     switch (Runtime.workspace.manager) {
       case 'npm':
       case 'yarn':
-      case 'pnpm': args = ['publish', '--tag', versionTag, '--access', 'public']; break;
+      case 'pnpm': args = ['publish', '--tag', versionTag, '--access', 'public', ...(otp ? ['--otp', otp] : [])]; break;
     }
     return spawn(Runtime.workspace.manager, args, { cwd: module.sourcePath });
   }

--- a/module/repo/support/cli.repo_exec.ts
+++ b/module/repo/support/cli.repo_exec.ts
@@ -48,7 +48,7 @@ export class RepoExecCommand implements CliCommandShape {
         }
       }),
       {
-        progressMessage: module => `Running '${cmd} ${finalArgs.join(' ')}' [%idx/%total] ${module?.sourceFolder ?? ''}`,
+        progressMessage: module => `Running '${cmd} ${finalArgs.join(' ')}' [%completed/%total] ${module?.sourceFolder ?? ''}`,
         showStdout: this.showStdout,
         prefixOutput: this.prefixOutput,
         workerCount: this.workers,

--- a/module/repo/support/cli.repo_publish.ts
+++ b/module/repo/support/cli.repo_publish.ts
@@ -1,6 +1,5 @@
 import { type CliCommandShape, CliCommand, cliTpl } from '@travetto/cli';
 import { RuntimeError } from '@travetto/runtime';
-import { TerminalUtil } from '@travetto/terminal';
 
 import { PackageManager } from './bin/package-manager.ts';
 import { RepoExecUtil } from './bin/exec.ts';
@@ -43,11 +42,10 @@ export class RepoPublishCommand implements CliCommandShape {
         throw new RuntimeError('NPM login is required to publish. Please run "npm login" to authenticate.');
       }
       if (!otp && await PackageManager.needsOtp()) {
-        if (TerminalUtil.isInteractive()) {
-          otp = await PackageManager.requestOtp();
-        } else {
-          throw new RuntimeError('OTP token is required for publishing, but was not provided.');
-        }
+        otp = await PackageManager.requestOtp();
+      }
+      if (!otp) {
+        throw new RuntimeError('OTP token is required for publishing, but was not provided.');
       }
     }
 

--- a/module/repo/support/cli.repo_publish.ts
+++ b/module/repo/support/cli.repo_publish.ts
@@ -22,7 +22,7 @@ export class RepoPublishCommand implements CliCommandShape {
   async main(): Promise<void> {
     const published = await RepoExecUtil.execOnModules('workspace', module => PackageManager.isPublished(module), {
       filter: module => !!module.workspace && !module.internal,
-      progressMessage: (module) => `Checking published [%completed/%total] -- ${module?.name}`,
+      progressMessage: (module) => `Checking published [%completed/%total] -- ${module?.name ?? ''}`,
       showStderr: false,
       showProgressList: true,
       isSuccess: () => true
@@ -55,7 +55,7 @@ export class RepoPublishCommand implements CliCommandShape {
       'workspace',
       module => PackageManager.publish(module, this.dryRun, otp),
       {
-        progressMessage: () => 'Publishing (%completed/%total) -- (Failed %failed)',
+        progressMessage: (module) => `Publishing [%completed/%total] -- ${module?.name ?? ''} (Failed %failed)`,
         showStdout: false,
         showStderr: false,
         showProgressList: true,

--- a/module/repo/support/cli.repo_publish.ts
+++ b/module/repo/support/cli.repo_publish.ts
@@ -1,4 +1,4 @@
-import { type CliCommandShape, CliCommand } from '@travetto/cli';
+import { type CliCommandShape, CliCommand, cliTpl } from '@travetto/cli';
 
 import { PackageManager } from './bin/package-manager.ts';
 import { RepoExecUtil } from './bin/exec.ts';
@@ -15,28 +15,55 @@ export class RepoPublishCommand implements CliCommandShape {
   /** Dry Run? */
   dryRun = true;
 
+  /** OTP Token */
+  otp?: string;
+
   async main(): Promise<void> {
     const published = await RepoExecUtil.execOnModules('workspace', module => PackageManager.isPublished(module), {
       filter: module => !!module.workspace && !module.internal,
       progressMessage: (module) => `Checking published [%idx/%total] -- ${module?.name}`,
       showStderr: false,
       showProgressList: true,
-      transformResult: (module, result) => PackageManager.validatePublishedResult(result),
     });
 
+    const unpublished = [...published.entries()]
+      .filter(entry => !PackageManager.validatePublishedResult(entry[1]))
+      .map(([module]) => module);
+
     if (this.dryRun) {
-      console.log('Unpublished modules', [...published.entries()].filter(entry => !entry[1]).map(([module]) => module.sourceFolder));
+      console.log('Unpublished modules', unpublished.map(module => module.sourceFolder));
     }
 
-    await RepoExecUtil.execOnModules(
-      'workspace', module => PackageManager.publish(module, this.dryRun),
+    let otp = this.otp;
+    if (unpublished.length > 0 && !this.dryRun) {
+      if (!otp && await PackageManager.needsOtp()) {
+        otp = await PackageManager.requestOtp();
+      }
+    }
+
+    const unpublishedSet = new Set(unpublished);
+
+    const results = await RepoExecUtil.execOnModules(
+      'workspace',
+      module => PackageManager.publish(module, this.dryRun, otp),
       {
-        progressMessage: (module) => `Published [%idx/%total] -- ${module?.name}`,
+        progressMessage: () => 'Publishing (%idx/%total) -- (%failed)',
         showStdout: false,
         showStderr: false,
         showProgressList: true,
-        filter: module => published.get(module) === false
+        filter: module => unpublishedSet.has(module)
       }
     );
+
+    const failures = [...results.entries()].filter(([, result]) => !result.valid);
+    if (failures.length > 0) {
+      console.error(cliTpl`\n${{ title: 'Failed to publish the following modules:' }}`);
+      console.error(cliTpl`${'-'.repeat(50)}`);
+      const nameWidth = Math.max(...failures.map(([module]) => module.name.length));
+      for (const [module, result] of failures) {
+        console.error(cliTpl`${{ identifier: module.name.padStart(nameWidth, ' ') }}: ${{ description: PackageManager.classifyPublishError(result) }}`);
+      }
+      process.exitCode = 1;
+    }
   }
 }

--- a/module/repo/support/cli.repo_publish.ts
+++ b/module/repo/support/cli.repo_publish.ts
@@ -23,9 +23,10 @@ export class RepoPublishCommand implements CliCommandShape {
   async main(): Promise<void> {
     const published = await RepoExecUtil.execOnModules('workspace', module => PackageManager.isPublished(module), {
       filter: module => !!module.workspace && !module.internal,
-      progressMessage: (module) => `Checking published [%idx/%total] -- ${module?.name}`,
+      progressMessage: (module) => `Checking published [%completed/%total] -- ${module?.name}`,
       showStderr: false,
       showProgressList: true,
+      isSuccess: () => true
     });
 
     const unpublished = [...published.entries()]
@@ -56,7 +57,7 @@ export class RepoPublishCommand implements CliCommandShape {
       'workspace',
       module => PackageManager.publish(module, this.dryRun, otp),
       {
-        progressMessage: () => 'Publishing (%idx/%total) -- (%failed)',
+        progressMessage: () => 'Publishing (%completed/%total) -- (Failed %failed)',
         showStdout: false,
         showStderr: false,
         showProgressList: true,

--- a/module/repo/support/cli.repo_publish.ts
+++ b/module/repo/support/cli.repo_publish.ts
@@ -1,4 +1,6 @@
 import { type CliCommandShape, CliCommand, cliTpl } from '@travetto/cli';
+import { RuntimeError } from '@travetto/runtime';
+import { TerminalUtil } from '@travetto/terminal';
 
 import { PackageManager } from './bin/package-manager.ts';
 import { RepoExecUtil } from './bin/exec.ts';
@@ -27,7 +29,7 @@ export class RepoPublishCommand implements CliCommandShape {
     });
 
     const unpublished = [...published.entries()]
-      .filter(entry => !PackageManager.validatePublishedResult(entry[1]))
+      .filter(([, result]) => !PackageManager.validatePublishedResult(result))
       .map(([module]) => module);
 
     if (this.dryRun) {
@@ -36,8 +38,15 @@ export class RepoPublishCommand implements CliCommandShape {
 
     let otp = this.otp;
     if (unpublished.length > 0 && !this.dryRun) {
+      if (await PackageManager.needsLogin()) {
+        throw new RuntimeError('NPM login is required to publish. Please run "npm login" to authenticate.');
+      }
       if (!otp && await PackageManager.needsOtp()) {
-        otp = await PackageManager.requestOtp();
+        if (TerminalUtil.isInteractive()) {
+          otp = await PackageManager.requestOtp();
+        } else {
+          throw new RuntimeError('OTP token is required for publishing, but was not provided.');
+        }
       }
     }
 

--- a/module/runtime/src/codec.ts
+++ b/module/runtime/src/codec.ts
@@ -54,10 +54,7 @@ export class CodecUtil {
   }
 
   /** Return utf8 string from bytes  */
-  static toUTF8String(value: BinaryArray | string): string {
-    if (typeof value === 'string') {
-      return value;
-    }
+  static toUTF8String(value: BinaryArray): string {
     return UTF8_DECODER.decode(BinaryUtil.binaryArrayToUint8Array(value));
   }
 

--- a/module/runtime/src/codec.ts
+++ b/module/runtime/src/codec.ts
@@ -54,7 +54,10 @@ export class CodecUtil {
   }
 
   /** Return utf8 string from bytes  */
-  static toUTF8String(value: BinaryArray): string {
+  static toUTF8String(value: BinaryArray | string): string {
+    if (typeof value === 'string') {
+      return value;
+    }
     return UTF8_DECODER.decode(BinaryUtil.binaryArrayToUint8Array(value));
   }
 

--- a/module/runtime/src/exec.ts
+++ b/module/runtime/src/exec.ts
@@ -40,6 +40,18 @@ type ExecutionBaseResult = Omit<ExecutionResult, 'stdout' | 'stderr'>;
  */
 export class ExecUtil {
 
+  /** Read stream as string from a result */
+  static toString(result: ExecutionResult<BinaryArray | string>, stream: 'stdout' | 'stderr' | 'any'): string {
+    if (stream === 'any') {
+      return this.toString(result, 'stderr') || this.toString(result, 'stdout');
+    }
+    const value = result[stream];
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    return CodecUtil.toUTF8String(value).trim();
+  }
+
   /**
    * Take a child process, and some additional options, and produce a promise that
    * represents the entire execution.  On successful completion the promise will resolve, and

--- a/module/runtime/test/exec.ts
+++ b/module/runtime/test/exec.ts
@@ -17,10 +17,10 @@ export class ExecUtilTest {
 
   @Test()
   async spawn() {
-    const proc = spawn('ls', ['-ls'], {
+    const process = spawn('ls', ['-ls'], {
       cwd: Runtime.workspace.path
     });
-    const result = await ExecUtil.getResult(proc);
+    const result = await ExecUtil.getResult(process);
     assert(result.stdout.includes('package.json'));
     assert(result.code === 0);
     assert(result.valid);
@@ -28,10 +28,10 @@ export class ExecUtilTest {
 
   @Test()
   async spawnBad() {
-    const proc = spawn('ls', ['xxxx'], {
+    const process = spawn('ls', ['xxxx'], {
       cwd: Runtime.workspace.path
     });
-    const result = await ExecUtil.getResult(proc, { catch: true });
+    const result = await ExecUtil.getResult(process, { catch: true });
     assert(result.stderr.includes('xxxx'));
     assert(result.code > 0);
     assert(!result.valid);
@@ -39,10 +39,10 @@ export class ExecUtilTest {
 
   @Test()
   async fork() {
-    const proc = fork(await this.fixture.resolve('echo.js'), { stdio: 'pipe' });
-    proc.stdin?.write('Hello World');
-    proc.stdin?.end();
-    const result = await ExecUtil.getResult(proc);
+    const process = fork(await this.fixture.resolve('echo.js'), { stdio: 'pipe' });
+    process.stdin?.write('Hello World');
+    process.stdin?.end();
+    const result = await ExecUtil.getResult(process);
     assert(result.stdout === 'Hello World');
   }
 
@@ -50,7 +50,7 @@ export class ExecUtilTest {
   async pipe() {
     const src = await this.fixture.readBinaryStream('/logo.png');
 
-    const proc = spawn('gm', [
+    const process = spawn('gm', [
       'convert', '-resize', '100x',
       '-auto-orient', '-strip', '-quality', '86',
       '-', '-'
@@ -59,8 +59,8 @@ export class ExecUtilTest {
     const tempFile = path.resolve(os.tmpdir(), `${Math.random()}.png`);
 
     await Promise.all([
-      pipeline(src, proc.stdin!),
-      pipeline(proc.stdout!, createWriteStream(tempFile))
+      pipeline(src, process.stdin!),
+      pipeline(process.stdout!, createWriteStream(tempFile))
     ]);
 
     const test = await fs.stat(tempFile);
@@ -70,9 +70,9 @@ export class ExecUtilTest {
 
   @Test()
   async testImmediateFail() {
-    const proc = spawn('npm', ['run', 'Cork'], { cwd: Runtime.workspace.path });
+    const process = spawn('npm', ['run', 'Cork'], { cwd: Runtime.workspace.path });
     await timers.setTimeout(600);
-    const failure = await ExecUtil.getResult(proc, { catch: true });
+    const failure = await ExecUtil.getResult(process, { catch: true });
     assert(!failure.valid);
   }
 }

--- a/module/terminal/src/util.ts
+++ b/module/terminal/src/util.ts
@@ -5,8 +5,8 @@ import { Env } from '@travetto/runtime';
 import { StyleUtil, type TermStyleFn, type TermStyleInput } from './style.ts';
 import { type Terminal, WAIT_TOKEN } from './terminal.ts';
 
-export type ProgressEvent<T> = { total?: number, idx: number, value: T };
-type ProgressStyle = { complete: TermStyleFn, incomplete?: TermStyleFn };
+export type ProgressEvent<T> = { total?: number, completed: number, value: T, failed?: number };
+type ProgressStyle = { complete: TermStyleFn, failed: TermStyleFn, incomplete?: TermStyleFn };
 
 export class TerminalUtil {
 
@@ -39,11 +39,12 @@ export class TerminalUtil {
     term: Terminal,
     config?: {
       withWaiting?: boolean;
-      style?: { complete: TermStyleInput, incomplete?: TermStyleInput } | (() => ProgressStyle);
+      style?: { complete: TermStyleInput, failed?: TermStyleInput, incomplete?: TermStyleInput } | (() => ProgressStyle);
     }
   ): (event: ProgressEvent<string>) => string {
     const styleBase = typeof config?.style !== 'function' ? {
       complete: StyleUtil.getStyle(config?.style?.complete ?? { background: '#248613', text: '#ffffff' }),
+      failed: StyleUtil.getStyle({ background: '#880000', text: '#ffffff', inverse: false }),
       incomplete: config?.style?.incomplete ? StyleUtil.getStyle(config.style.incomplete) : undefined,
     } : undefined;
 
@@ -51,19 +52,25 @@ export class TerminalUtil {
 
     let width: number;
     return event => {
-      const text = event.value ?? (event.total ? '%idx/%total' : '%idx');
-      const progress = event.total === undefined ? 0 : (event.idx / event.total);
+      const text = event.value ?? (event.total ? '%completed/%total' : '%completed');
+      const progress = event.total === undefined ? 0 : (event.completed / event.total);
       if (event.total) {
         width ??= Math.trunc(Math.ceil(Math.log10(event.total ?? 10000)));
       }
-      const state: Record<string, string> = { total: `${event.total}`, idx: `${event.idx}`.padStart(width ?? 0), progress: `${Math.trunc(progress * 100)}` };
-      const line = ` ${text.replace(/[%](idx|total|progress)/g, (_, key) => state[key])} `;
+      const state: Record<string, string> = {
+        total: `${event.total}`,
+        completed: `${event.completed}`.padStart(width ?? 0),
+        progress: `${Math.trunc(progress * 100)}`,
+        failed: event.failed ? `${event.failed}` : ''
+      };
+      const line = ` ${text.replace(/[%](completed|total|progress|failed)/g, (_, key) => state[key])} `;
       const full = term.writer.padToWidth(line, config?.withWaiting ? 2 : 0);
       const mid = Math.trunc(progress * term.width);
       const [left, right] = [full.substring(0, mid), full.substring(mid)];
 
-      const { complete, incomplete } = style();
-      return `${config?.withWaiting ? `${WAIT_TOKEN} ` : ''}${complete(left)}${incomplete?.(right) ?? right}`;
+      const { complete, incomplete, failed } = style();
+      const color = event.failed ? failed : complete;
+      return `${config?.withWaiting ? `${WAIT_TOKEN} ` : ''}${color(left)}${incomplete?.(right) ?? right}`;
     };
   }
 }

--- a/module/terminal/src/util.ts
+++ b/module/terminal/src/util.ts
@@ -1,10 +1,36 @@
+import rl from 'node:readline/promises';
+
+import { Env } from '@travetto/runtime';
+
 import { StyleUtil, type TermStyleFn, type TermStyleInput } from './style.ts';
 import { type Terminal, WAIT_TOKEN } from './terminal.ts';
 
-type ProgressEvent<T> = { total?: number, idx: number, value: T };
+export type ProgressEvent<T> = { total?: number, idx: number, value: T };
 type ProgressStyle = { complete: TermStyleFn, incomplete?: TermStyleFn };
 
 export class TerminalUtil {
+
+  /**
+   * Determine if the terminal session is interactive
+   */
+  static isInteractive(): boolean {
+    return process.stdout.isTTY && process.stdin.isTTY && !Env.TRV_QUIET.isTrue;
+  }
+
+  /**
+   * Prompt the user for input
+   */
+  static async prompt(message: string): Promise<string> {
+    if (!this.isInteractive()) {
+      return '';
+    }
+    const reader = rl.createInterface({ input: process.stdin, output: process.stdout });
+    try {
+      return (await reader.question(message)).trim();
+    } finally {
+      reader.close();
+    }
+  }
 
   /**
    * Create a progress bar updater, suitable for streaming to the bottom of the screen

--- a/module/test/src/consumer/types/tap-summary.ts
+++ b/module/test/src/consumer/types/tap-summary.ts
@@ -106,7 +106,7 @@ export class TapSummaryEmitter implements TestConsumerShape {
         (value) => {
           TestModelUtil.countTestResult(total, [value]);
           const statusLine = `${total.failed} failed, ${total.errored} errored, ${total.skipped} skipped`;
-          return { value: `Tests %idx/%total [${statusLine}] -- ${value.classId}`, total: this.#state.testCount, idx: total.passed };
+          return { value: `Tests %completed/%total [${statusLine}] -- ${value.classId}`, total: this.#state.testCount, completed: total.passed };
         },
         TerminalUtil.progressBarUpdater(this.#terminal, { style: () => ({ complete: (total.failed || total.errored) ? fail : success }) })
       ),

--- a/module/worker/__index__.ts
+++ b/module/worker/__index__.ts
@@ -1,2 +1,3 @@
 export * from './src/ipc.ts';
 export * from './src/pool.ts';
+export * from './src/types.ts';

--- a/module/worker/src/pool.ts
+++ b/module/worker/src/pool.ts
@@ -5,7 +5,7 @@ import { Env, Util, AsyncQueue } from '@travetto/runtime';
 
 import {
   isWorkerFactory, WorkPoolResultError, type IterableSource, type Worker, type WorkerInput,
-  type WorkPoolCompleteEvent, type WorkPoolConfig
+  type WorkPoolCompleteEvent, type WorkPoolConfig, type WorkPoolProgress
 } from './types.ts';
 
 /**
@@ -81,10 +81,10 @@ export class WorkPool {
 
     const pool = this.#buildPool(workerFactory, options);
 
-    const progress = {
-      progress: 0,
+    const progress: WorkPoolProgress = {
+      completed: 0,
       total: options.total ?? 0,
-      failures: 0,
+      failed: 0,
     };
 
     for await (const nextInput of source) {
@@ -100,14 +100,14 @@ export class WorkPool {
       const completion = worker.execute(nextInput, inputIdx += 1)
         .then(output => {
           const success = options.isSuccess?.(output) ?? true;
-          progress.failures += +!success;
-          progress.progress += 1;
+          progress.failed += +!success;
+          progress.completed += 1;
           return options.onComplete?.({ output, input: nextInput, success, progress });
         })
         .catch(error => {
           errors.push(error);
-          progress.failures += 1;
-          progress.progress += 1;
+          progress.failed += 1;
+          progress.completed += 1;
           options?.onError?.({ error, input: nextInput, progress });
         }) // Catch error
         .finally(async () => {

--- a/module/worker/src/pool.ts
+++ b/module/worker/src/pool.ts
@@ -1,32 +1,12 @@
 import os from 'node:os';
-import { type Options, type Pool, createPool } from 'generic-pool';
+import { type Pool, createPool } from 'generic-pool';
 
 import { Env, Util, AsyncQueue } from '@travetto/runtime';
 
-type IterableSource<I> = Iterable<I> | AsyncIterable<I>;
-type WorkerExecutor<I, O> = (input: I, idx: number) => Promise<O>;
-
-/**
- * Worker definition
- */
-export interface Worker<I, O = unknown> {
-  active: boolean;
-  id: unknown;
-  init?(): Promise<unknown>;
-  execute: WorkerExecutor<I, O>;
-  destroy?(): Promise<void>;
-  release?(): unknown;
-}
-
-type WorkerFactoryInput<I, O = unknown> = Partial<Worker<I, O>> & { execute: WorkerExecutor<I, O> };
-type WorkerInput<I, O> = (() => WorkerFactoryInput<I, O>) | WorkerExecutor<I, O>;
-type WorkPoolConfig<I, O> = Options & {
-  onComplete?: (output: O, input: I, finishIdx: number) => void;
-  onError?(event: Error, input: I, finishIdx: number): (unknown | Promise<unknown>);
-  shutdown?: AbortSignal;
-};
-
-const isWorkerFactory = <I, O>(value: WorkerInput<I, O>): value is (() => WorkerFactoryInput<I, O>) => value.length === 0;
+import {
+  isWorkerFactory, WorkPoolResultError, type IterableSource, type Worker, type WorkerInput,
+  type WorkPoolCompleteEvent, type WorkPoolConfig
+} from './types.ts';
 
 /**
  * Work pool support
@@ -36,21 +16,26 @@ export class WorkPool {
   static MAX_SIZE = os.availableParallelism();
   static DEFAULT_SIZE = Math.max(Math.trunc(WorkPool.MAX_SIZE * .75), 4);
 
+  static #shouldTrace(): boolean {
+    return (Env.DEBUG.value ?? '').includes('@travetto/worker');
+  }
+
   /** Build worker pool */
   static #buildPool<I, O>(input: WorkerInput<I, O>, options?: WorkPoolConfig<I, O>): Pool<Worker<I, O>> {
     let pendingAcquires = 0;
 
-    const trace = /@travetto\/worker/.test(Env.DEBUG.value ?? '');
+    const trace = this.#shouldTrace();
 
     // Create the pool
     const pool = createPool({
       async create() {
         try {
           pendingAcquires += 1;
+          const factoryInput = isWorkerFactory(input) ? await input() : { execute: input };
           const worker: Worker<I, O> = {
             id: Util.uuid(),
             active: true,
-            ...isWorkerFactory(input) ? input() : { execute: input }
+            ...factoryInput,
           };
           await worker.init?.();
           return worker;
@@ -89,13 +74,18 @@ export class WorkPool {
    */
   static async run<I, O>(workerFactory: WorkerInput<I, O>, source: IterableSource<I>, options: WorkPoolConfig<I, O> = {}): Promise<void> {
 
-    const trace = /@travetto\/worker/.test(Env.DEBUG.value ?? '');
+    const trace = this.#shouldTrace();
     const pending = new Set<Promise<unknown>>();
     const errors: Error[] = [];
     let inputIdx = 0;
-    let finishIdx = 0;
 
     const pool = this.#buildPool(workerFactory, options);
+
+    const progress = {
+      progress: 0,
+      total: options.total ?? 0,
+      failures: 0,
+    };
 
     for await (const nextInput of source) {
       const worker = await pool.acquire()!;
@@ -103,12 +93,22 @@ export class WorkPool {
       if (trace) {
         console.debug('Acquired', { pid: process.pid, worker: worker.id });
       }
+      if (!options.total) {
+        progress.total = inputIdx + 1;
+      }
 
       const completion = worker.execute(nextInput, inputIdx += 1)
-        .then(output => options.onComplete?.(output, nextInput, finishIdx += 1))
+        .then(output => {
+          const success = options.isSuccess?.(output) ?? true;
+          progress.failures += +!success;
+          progress.progress += 1;
+          return options.onComplete?.({ output, input: nextInput, success, progress });
+        })
         .catch(error => {
           errors.push(error);
-          options?.onError?.(error, nextInput, finishIdx += 1);
+          progress.failures += 1;
+          progress.progress += 1;
+          options?.onError?.({ error, input: nextInput, progress });
         }) // Catch error
         .finally(async () => {
           if (trace) {
@@ -133,40 +133,21 @@ export class WorkPool {
     await Promise.all(Array.from(pending));
 
     if (errors.length) {
-      throw errors[0];
+      throw new WorkPoolResultError(errors);
     }
-  }
-
-  /**
-   * Process a given input source as an async iterable
-   */
-  static runStream<I, O>(worker: WorkerInput<I, O>, input: IterableSource<I>, options?: WorkPoolConfig<I, O>): AsyncIterable<O> {
-    const queue = new AsyncQueue<O>();
-    const result = this.run(worker, input, {
-      ...options,
-      onComplete: (event, value, finishIdx) => {
-        queue.add(event);
-        options?.onComplete?.(event, value, finishIdx);
-      }
-    });
-    result.finally(() => queue.close());
-    return queue;
   }
 
   /**
    * Process a given input source as an async iterable with progress information
    */
-  static runStreamProgress<I, O>(worker: WorkerInput<I, O>, input: IterableSource<I>, total: number, options?: WorkPoolConfig<I, O>): AsyncIterable<{
-    idx: number;
-    value: O;
-    total: number;
-  }> {
-    const queue = new AsyncQueue<{ idx: number, value: O, total: number }>();
-    const result = this.run(worker, input, {
+  static runStream<I, O>(worker: WorkerInput<I, O>, source: IterableSource<I>, options?: WorkPoolConfig<I, O>): AsyncIterable<WorkPoolCompleteEvent<I, O>> {
+    const queue = new AsyncQueue<WorkPoolCompleteEvent<I, O>>();
+    const result = this.run(worker, source, {
       ...options,
-      onComplete: (event, value, finishIdx) => {
-        queue.add({ value: event, idx: finishIdx, total });
-        options?.onComplete?.(event, value, finishIdx);
+      onComplete: async (event) => {
+        await options?.onComplete?.(event);
+        queue.add(event);
+        return;
       }
     });
     result.finally(() => queue.close());

--- a/module/worker/src/types.ts
+++ b/module/worker/src/types.ts
@@ -1,0 +1,60 @@
+import type { Options } from 'generic-pool';
+
+import { RuntimeError } from '@travetto/runtime';
+
+export type IterableSource<I> = Iterable<I> | AsyncIterable<I>;
+export type WorkerExecutor<I, O> = (input: I, idx: number) => Promise<O>;
+
+/**
+ * WorkPool results error.
+ *
+ * Hold all the errors for a given work pool execution
+ */
+export class WorkPoolResultError extends RuntimeError<{ errors: Error[] }> {
+  constructor(errors: Error[]) {
+    super('WorkPool errors have occurred', { category: 'data', details: { errors } });
+  }
+}
+
+/**
+ * Worker definition
+ */
+export interface Worker<I, O = unknown> {
+  active: boolean;
+  id: unknown;
+  init?(): Promise<unknown>;
+  execute: WorkerExecutor<I, O>;
+  destroy?(): Promise<void>;
+  release?(): unknown;
+}
+
+type WorkPoolProgress = {
+  total: number;
+  progress: number;
+  failures: number;
+};
+
+export type WorkPoolCompleteEvent<I, O> = {
+  output: O;
+  input: I;
+  success: boolean;
+  progress: WorkPoolProgress;
+};
+
+export type WorkPoolErrorEvent<I> = {
+  error: Error;
+  input: I;
+  progress: WorkPoolProgress;
+};
+
+export type WorkerFactoryInput<I, O = unknown> = Partial<Worker<I, O>> & { execute: WorkerExecutor<I, O> };
+export type WorkerInput<I, O> = (() => (WorkerFactoryInput<I, O> | Promise<WorkerFactoryInput<I, O>>)) | WorkerExecutor<I, O>;
+export type WorkPoolConfig<I, O> = Options & {
+  isSuccess?: (output: O) => boolean;
+  onComplete?: (event: WorkPoolCompleteEvent<I, O>) => void | Promise<void>;
+  onError?<R = unknown>(event: WorkPoolErrorEvent<I>): (R | Promise<R>);
+  shutdown?: AbortSignal;
+  total?: number;
+};
+
+export const isWorkerFactory = <I, O>(value: WorkerInput<I, O>): value is (() => (WorkerFactoryInput<I, O> | Promise<WorkerFactoryInput<I, O>>)) => value.length === 0;

--- a/module/worker/src/types.ts
+++ b/module/worker/src/types.ts
@@ -28,10 +28,10 @@ export interface Worker<I, O = unknown> {
   release?(): unknown;
 }
 
-type WorkPoolProgress = {
+export type WorkPoolProgress = {
   total: number;
-  progress: number;
-  failures: number;
+  completed: number;
+  failed: number;
 };
 
 export type WorkPoolCompleteEvent<I, O> = {

--- a/module/worker/test/pool.ts
+++ b/module/worker/test/pool.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert';
+
+import { Test, Suite } from '@travetto/test';
+import { WorkPool, WorkPoolResultError } from '@travetto/worker';
+
+@Suite()
+export class WorkPoolTest {
+
+  @Test()
+  async testSimpleRun() {
+    const inputs = [1, 2, 3, 4, 5];
+    const completedInputs: number[] = [];
+    let completeCount = 0;
+
+    await WorkPool.run(
+      async (input) => {
+        return input * 2;
+      },
+      inputs,
+      {
+        max: 1,
+        total: 5,
+        onComplete: ({ output, input, success, progress }) => {
+          completedInputs.push(input);
+          completeCount++;
+          assert.equal(output, input * 2);
+          assert.equal(success, true);
+          assert.equal(progress.completed, completeCount);
+          assert.equal(progress.total, 5);
+          assert.equal(progress.failed, 0);
+        }
+      }
+    );
+
+    assert.equal(completedInputs.length, 5);
+    completedInputs.sort((a, b) => a - b);
+    assert.deepEqual(completedInputs, [1, 2, 3, 4, 5]);
+  }
+
+  @Test()
+  async testIsSuccess() {
+    const inputs = [1, 2, 3, 4, 5];
+    let failedCount = 0;
+
+    await WorkPool.run(
+      async (input) => input,
+      inputs,
+      {
+        max: 2,
+        isSuccess: (output) => output % 2 !== 0,
+        onComplete: ({ output, success, progress }) => {
+          if (!success) {
+            failedCount++;
+          }
+          assert.equal(success, output % 2 !== 0);
+          assert.equal(progress.failed, failedCount);
+        }
+      }
+    );
+
+    assert.equal(failedCount, 2);
+  }
+
+  @Test()
+  async testErrorAccumulation() {
+    const inputs = [1, 2, 3];
+
+    await assert.rejects(
+      async () => {
+        await WorkPool.run(
+          async (input) => {
+            if (input === 2 || input === 3) {
+              throw new Error(`Error ${input}`);
+            }
+            return input;
+          },
+          inputs,
+          {
+            max: 1
+          }
+        );
+      },
+      (err) => {
+        assert(err instanceof WorkPoolResultError);
+        assert.equal(err.details.errors.length, 2);
+        assert.equal(err.details.errors[0].message, 'Error 2');
+        assert.equal(err.details.errors[1].message, 'Error 3');
+        return true;
+      }
+    );
+  }
+
+  @Test()
+  async testRunStream() {
+    const inputs = [10, 20, 30];
+    const results: number[] = [];
+
+    const stream = WorkPool.runStream(
+      async (input) => input + 1,
+      inputs,
+      { max: 2 }
+    );
+
+    for await (const event of stream) {
+      results.push(event.output);
+      assert.equal(event.success, true);
+      assert(event.progress.completed >= 1 && event.progress.completed <= 3);
+    }
+
+    assert.equal(results.length, 3);
+    results.sort((a, b) => a - b);
+    assert.deepEqual(results, [11, 21, 31]);
+  }
+}

--- a/support/cli.doc_angular.ts
+++ b/support/cli.doc_angular.ts
@@ -81,7 +81,7 @@ export class DocAngularCommand {
         },
         {
           showStdout: false,
-          progressMessage: module => `Running 'trv doc' [%idx/%total] ${module?.sourceFolder ?? ''}`,
+          progressMessage: module => `Running 'trv doc' [%completed/%total] ${module?.sourceFolder ?? ''}`,
           includeMonorepoRoot: true,
           filter: module => modules.has(module),
           showProgressList: true


### PR DESCRIPTION
This PR adds support for OTP (Two-Factor Authentication) tokens and NPM login checks when publishing packages from the monorepo, and enhances the worker pool to support rich progress updates.

### Changes:
- **`@travetto/repo`**:
  - Adds checking for NPM authentication (`needsLogin()`) and OTP state (`needsOtp()`) before publishing.
  - Prompts for OTP token interactively via `TerminalUtil.prompt` if required, or raises an error if non-interactive.
  - Standardizes error classification (`classifyPublishError()`) to categorize OTP failure, version conflicts, permission issues, or authentication issues.
  - Summarizes failed publications clearly at the end of the script.
- **`@travetto/worker`**:
  - Refactors worker pool (`WorkPool`) to track worker completion, total count, and failure status.
  - Enhances options to include success/failure callbacks and `isSuccess` validator.
  - Replaces `runStream` and `runStreamProgress` with a more unified and flexible stream handler `runStream`.
