### PR TITLE
chore(cli,test): touch up CLI help rendering, debug descriptions, and test summary formatting

### DIFF
--- a/module/cli/src/help.ts
+++ b/module/cli/src/help.ts
@@ -33,60 +33,43 @@ const COMMAND_TO_MODULE = Object.fromEntries(Object.entries(MODULE_TO_COMMAND).f
  */
 export class HelpUtil {
 
-  /** Render the unknown command message */
-  static renderUnknownCommandMessage(command: string): string {
-    const module = COMMAND_TO_MODULE[command];
-    if (module) {
-      return cliTpl`
-${{ title: 'Missing Package' }}\n${'-'.repeat(20)}\nTo use ${{ input: command }} please run:\n
-${{ identifier: Runtime.getInstallCommand(module) }}
-`;
-    } else {
-      return cliTpl`${{ subtitle: 'Unknown command' }}: ${{ input: command }}`;
-    }
-  }
-
-  /**
-   * Render command-specific help
-   * @param command
-   */
-  static async renderCommandHelp(command: CliCommandShape): Promise<string> {
+  /** Get usage help for a command */
+  static getUsageMessage(command: CliCommandShape): string[] {
     const schema = SchemaRegistryIndex.getConfig(getClass(command));
     const { name: commandName } = CliCommandRegistryIndex.get(getClass(command));
-    const args = schema.methods.main?.parameters ?? [];
 
     const usage: string[] = [];
-    const params: string[] = [];
-    const descriptions: string[] = [];
 
     usage.push(
       cliTpl`${{ title: 'Usage:' }} ${{ param: commandName }} ${{ input: '[options]' }}`
     );
 
     // Ensure finalized
-    for (const field of args) {
+    for (const field of schema.methods.main?.parameters ?? []) {
       const type = field.type === String && field.enum && field.enum?.values.length <= 7 ? field.enum?.values?.join('|') : field.type.name.toLowerCase();
       const arg = `${field.name}${field.array ? '...' : ''}:${type}`;
       usage.push(cliTpl`${{ input: field.required?.active !== false ? `<${arg}>` : `[${arg}]` }}`);
     }
+    usage.push('');
+    return usage;
+  }
 
-
+  /** Get description help for a command */
+  static getDescriptionMessage(command: CliCommandShape): string[] {
+    const schema = SchemaRegistryIndex.getConfig(getClass(command));
     const description: string[] = [];
 
     if (schema.description) {
-      description.push(schema.description);
+      description.push(cliTpl`${{ title: 'Description:' }}`, ...schema.description.split('\n').map(line => `  ${line}`), '');
     }
+    return description;
+  }
 
-    if (schema.examples) {
-      description.push(cliTpl`${{ title: 'Example Usage:' }}`);
-      for (const example of schema.examples) {
-        description.push(cliTpl`\t${example}`);
-      }
-    }
-
-    if (description.length) {
-      description.push('');
-    }
+  /** Get options help for a command */
+  static getOptionsMessage(command: CliCommandShape): string[] {
+    const schema = SchemaRegistryIndex.getConfig(getClass(command));
+    const params: string[] = [];
+    const descriptions: string[] = [];
 
     for (const field of Object.values(schema.fields)) {
       const key = castKey<CliCommandShape>(field.name);
@@ -128,21 +111,68 @@ ${{ identifier: Runtime.getInstallCommand(module) }}
     const paramWidth = Math.max(...paramWidths);
     const descWidth = Math.max(...descWidths);
 
-    const extendedHelpText = await (command.help?.() ?? []);
-    if (extendedHelpText.length && extendedHelpText.at(-1) !== '') {
-      extendedHelpText.push('');
-    }
-
-    return [
-      usage.join(' '),
-      '',
-      ...description,
+    const options: string[] = [
       cliTpl`${{ title: 'Options:' }}`,
       ...params.map((_, i) =>
         `  ${params[i]}${' '.repeat((paramWidth - paramWidths[i]))}  ${descriptions[i].padEnd(descWidth)}${' '.repeat((descWidth - descWidths[i]))}`
       ),
-      '',
-      ...extendedHelpText
+      ''
+    ];
+    return options;
+  }
+
+  /** Get extended help for a command */
+  static async getExtendedHelpMessage(command: CliCommandShape): Promise<string[]> {
+    const extendedHelpText = await (command.help?.() ?? []);
+    if (extendedHelpText.length && extendedHelpText.at(-1) !== '') {
+      extendedHelpText.push('');
+    }
+    return extendedHelpText;
+  }
+
+  /** Get examples for a command */
+  static getExamplesMessage(command: CliCommandShape): string[] {
+    const schema = SchemaRegistryIndex.getConfig(getClass(command));
+    const examples: string[] = [];
+    if (schema.examples) {
+      examples.push(cliTpl`${{ title: 'Examples:' }}`);
+      for (const example of schema.examples) {
+        for (const line of example.split('\n')) {
+          examples.push(
+            line.trim().startsWith('>') ?
+              cliTpl`    ${{ input: line.substring(line.indexOf('> ') + 2).trim() }}` :
+              cliTpl`  ${{ subtitle: line.trim() }}`);
+        }
+      }
+      examples.push('');
+    }
+    return examples;
+  }
+
+  /** Render the unknown command message */
+  static renderUnknownCommandMessage(command: string): string {
+    const module = COMMAND_TO_MODULE[command];
+    if (module) {
+      return cliTpl`
+${{ title: 'Missing Package' }}\n${'-'.repeat(20)}\nTo use ${{ input: command }} please run:\n
+${{ identifier: Runtime.getInstallCommand(module) }}
+`;
+    } else {
+      return cliTpl`${{ subtitle: 'Unknown command' }}: ${{ input: command }}`;
+    }
+  }
+
+  /**
+   * Render command-specific help
+   * @param command
+   */
+  static async renderCommandHelp(command: CliCommandShape): Promise<string> {
+    return [
+      ...this.getUsageMessage(command),
+      ...this.getDescriptionMessage(command),
+      ...this.getOptionsMessage(command),
+      ...await this.getExtendedHelpMessage(command),
+      ...this.getExamplesMessage(command)
     ].map(line => line.trimEnd()).join('\n');
   }
 

--- a/module/cli/src/registry/decorator.ts
+++ b/module/cli/src/registry/decorator.ts
@@ -147,7 +147,7 @@ export function CliDebugIpcFlag(config: CliFlagOptions = {}) {
     const cls = getClass(instance);
     SchemaRegistryIndex.getForRegister(cls).registerField(property, {
       ...CliParseUtil.buildAliases(config, Env.TRV_DEBUG_IPC.key),
-      description: 'Should the invocation automatically restart on source changes'
+      description: 'Should the invocation support debugging via IPC (e.g. from VSCode)'
     });
 
     CliCommandRegistryIndex.getForRegister(cls).register({ runTarget: true });

--- a/module/test/src/consumer/types/tap-summary.ts
+++ b/module/test/src/consumer/types/tap-summary.ts
@@ -106,9 +106,16 @@ export class TapSummaryEmitter implements TestConsumerShape {
         (value) => {
           TestModelUtil.countTestResult(total, [value]);
           const statusLine = `${total.failed} failed, ${total.errored} errored, ${total.skipped} skipped`;
-          return { value: `Tests %completed/%total [${statusLine}] -- ${value.classId}`, total: this.#state.testCount, completed: total.passed };
+          return {
+            value: `Tests %completed/%total [${statusLine}] -- ${value.classId}`,
+            total: this.#state.testCount,
+            completed: total.passed,
+            failed: total.failed + total.errored
+          };
         },
-        TerminalUtil.progressBarUpdater(this.#terminal, { style: () => ({ complete: (total.failed || total.errored) ? fail : success }) })
+        TerminalUtil.progressBarUpdater(this.#terminal, {
+          style: () => ({ complete: success, failed: fail })
+        })
       ),
       { minDelay: 100 }
     );

--- a/module/test/src/consumer/types/tap-summary.ts
+++ b/module/test/src/consumer/types/tap-summary.ts
@@ -1,5 +1,5 @@
 import { Util, AsyncQueue } from '@travetto/runtime';
-import { StyleUtil, Terminal, TerminalUtil } from '@travetto/terminal';
+import { Terminal, TerminalUtil } from '@travetto/terminal';
 
 import type { TestEvent } from '../../model/event.ts';
 import type { TestResult } from '../../model/test.ts';
@@ -98,8 +98,6 @@ export class TapSummaryEmitter implements TestConsumerShape {
     this.onTestRunState(state);
 
     const total = TestModelUtil.buildSummary();
-    const success = StyleUtil.getStyle({ text: '#e5e5e5', background: '#026020' }); // White on dark green
-    const fail = StyleUtil.getStyle({ text: '#e5e5e5', background: '#8b0000' }); // White on dark red
     this.#progress = this.#terminal.streamToBottom(
       Util.mapAsyncIterable(
         this.#results,
@@ -114,7 +112,10 @@ export class TapSummaryEmitter implements TestConsumerShape {
           };
         },
         TerminalUtil.progressBarUpdater(this.#terminal, {
-          style: () => ({ complete: success, failed: fail })
+          style: {
+            complete: { text: '#e5e5e5', background: '#026020' },
+            failed: { text: '#e5e5e5', background: '#8b0000' }
+          }
         })
       ),
       { minDelay: 100 }

--- a/module/web-http/support/cli.web_http.ts
+++ b/module/web-http/support/cli.web_http.ts
@@ -12,7 +12,9 @@ import type { WebHttpServer } from '../src/types.ts';
  * Initializes registry and server bindings, supports restart-aware development
  * flags, and can attempt to clear conflicting port owners in local workflows.
  *
- * @example trv web:http -m <MODULE> -p 3000
+ * @example
+ * Starting a web server on port 8000
+ * > trv web:http -m <MODULE> -p 8000
  */
 @CliCommand()
 export class WebHttpCommand implements CliCommandShape {


### PR DESCRIPTION
This PR introduces touch-ups and refactoring before cutting a release:

- **`@travetto/cli`**:
  - Refactors `HelpUtil.renderCommandHelp` in [help.ts](file:///Users/arcsine/Code/travetto/module/cli/src/help.ts) into smaller helper functions (`getUsageMessage`, `getDescriptionMessage`, `getOptionsMessage`, `getExtendedHelpMessage`, `getExamplesMessage`).
  - Cleans up and improves formatting of command example rendering.
  - Updates the description for the `CliDebugIpcFlag` in [decorator.ts](file:///Users/arcsine/Code/travetto/module/cli/src/registry/decorator.ts) to correctly describe support for VS Code IPC debugging.
- **`@travetto/test`**:
  - Updates `TapSummaryEmitter` in [tap-summary.ts](file:///Users/arcsine/Code/travetto/module/test/src/consumer/types/tap-summary.ts) to correctly pass the aggregate failure count (`failed: total.failed + total.errored`) to `progressBarUpdater` and maps the styles cleanly.
- **`@travetto/web-http`**:
  - Adjusts example annotations in [cli.web_http.ts](file:///Users/arcsine/Code/travetto/module/web-http/support/cli.web_http.ts) to follow the new example layout conventions.
