### PR TITLE
feat(model-s3): support configurable hostName and public URL generation

### DIFF
--- a/module/cli/src/help.ts
+++ b/module/cli/src/help.ts
@@ -50,8 +50,8 @@ export class HelpUtil {
       const arg = `${field.name}${field.array ? '...' : ''}:${type}`;
       usage.push(cliTpl`${{ input: field.required?.active !== false ? `<${arg}>` : `[${arg}]` }}`);
     }
-    usage.push('');
-    return usage;
+
+    return [usage.join(' '), ''];
   }
 
   /** Get description help for a command */

--- a/module/model-s3/DOC.html
+++ b/module/model-s3/DOC.html
@@ -74,9 +74,8 @@ where the <a target="_blank" class="source-link" href="https://github.com/travet
   <span class="token comment">/**
    * Provide host to bucket
    */</span>
-  <span class="token keyword">get</span> <span class="token function">hostName</span><span class="token punctuation">(</span><span class="token punctuation">)</span><span class="token operator">:</span> <span class="token builtin">string</span> <span class="token punctuation">{{'{'}}</span>
-    <span class="token keyword">return</span> <span class="token template-string"><span class="token template-punctuation string">`</span><span class="token interpolation"><span class="token interpolation-punctuation punctuation">${{'{'}}</span><span class="token keyword">this</span><span class="token punctuation">.</span>bucket<span class="token interpolation-punctuation punctuation">{{'}'}}</span></span><span class="token string">.s3.amazonaws.com</span><span class="token template-punctuation string">`</span></span><span class="token punctuation">;</span>
-  <span class="token punctuation">{{'}'}}</span>
+  <span class="token decorator"><span class="token at operator">@</span><span class="token function">Required</span></span><span class="token punctuation">(</span><span class="token boolean">false</span><span class="token punctuation">)</span>
+  hostName<span class="token operator">:</span> <span class="token builtin">string</span><span class="token punctuation">;</span>
 
   <span class="token comment">/**
    * Produces the s3 config from the provide details, post construction
@@ -86,6 +85,14 @@ where the <a target="_blank" class="source-link" href="https://github.com/travet
     <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span>Runtime<span class="token punctuation">.</span>production<span class="token punctuation">)</span> <span class="token punctuation">{{'{'}}</span>
       <span class="token keyword">this</span><span class="token punctuation">.</span>endpoint <span class="token operator">??=</span> <span class="token string">'http://localhost:4566'</span><span class="token punctuation">;</span> <span class="token comment">// From docker</span>
       <span class="token keyword">this</span><span class="token punctuation">.</span>bucket <span class="token operator">??=</span> <span class="token string">'app'</span><span class="token punctuation">;</span>
+    <span class="token punctuation">{{'}'}}</span>
+
+    <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token keyword">this</span><span class="token punctuation">.</span>hostName<span class="token punctuation">)</span> <span class="token punctuation">{{'{'}}</span>
+      <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token keyword">this</span><span class="token punctuation">.</span>endpoint <span class="token operator">&amp;&amp;</span> <span class="token operator">!</span><span class="token keyword">this</span><span class="token punctuation">.</span>endpoint<span class="token punctuation">.</span><span class="token function">includes</span><span class="token punctuation">(</span><span class="token string">'localhost'</span><span class="token punctuation">)</span><span class="token punctuation">)</span> <span class="token punctuation">{{'{'}}</span>
+        <span class="token keyword">this</span><span class="token punctuation">.</span>hostName <span class="token operator">=</span> <span class="token keyword">new</span> <span class="token class-name"><span class="token constant">URL</span></span><span class="token punctuation">(</span><span class="token keyword">this</span><span class="token punctuation">.</span>endpoint<span class="token punctuation">)</span><span class="token punctuation">.</span>host<span class="token punctuation">;</span>
+      <span class="token punctuation">{{'}'}}</span> <span class="token keyword">else</span> <span class="token punctuation">{{'{'}}</span>
+        <span class="token keyword">this</span><span class="token punctuation">.</span>hostName <span class="token operator">=</span> <span class="token template-string"><span class="token template-punctuation string">`</span><span class="token interpolation"><span class="token interpolation-punctuation punctuation">${{'{'}}</span><span class="token keyword">this</span><span class="token punctuation">.</span>bucket<span class="token interpolation-punctuation punctuation">{{'}'}}</span></span><span class="token string">.s3.amazonaws.com</span><span class="token template-punctuation string">`</span></span><span class="token punctuation">;</span>
+      <span class="token punctuation">{{'}'}}</span>
     <span class="token punctuation">{{'}'}}</span>
 
     <span class="token keyword">if</span> <span class="token punctuation">(</span><span class="token operator">!</span><span class="token keyword">this</span><span class="token punctuation">.</span>accessKeyId <span class="token operator">&amp;&amp;</span> <span class="token operator">!</span><span class="token keyword">this</span><span class="token punctuation">.</span>secretAccessKey<span class="token punctuation">)</span> <span class="token punctuation">{{'{'}}</span>

--- a/module/model-s3/README.md
+++ b/module/model-s3/README.md
@@ -67,9 +67,8 @@ export class S3ModelConfig {
   /**
    * Provide host to bucket
    */
-  get hostName(): string {
-    return `${this.bucket}.s3.amazonaws.com`;
-  }
+  @Required(false)
+  hostName: string;
 
   /**
    * Produces the s3 config from the provide details, post construction
@@ -79,6 +78,14 @@ export class S3ModelConfig {
     if (!Runtime.production) {
       this.endpoint ??= 'http://localhost:4566'; // From docker
       this.bucket ??= 'app';
+    }
+
+    if (!this.hostName) {
+      if (this.endpoint && !this.endpoint.includes('localhost')) {
+        this.hostName = new URL(this.endpoint).host;
+      } else {
+        this.hostName = `${this.bucket}.s3.amazonaws.com`;
+      }
     }
 
     if (!this.accessKeyId && !this.secretAccessKey) {

--- a/module/model-s3/src/config.ts
+++ b/module/model-s3/src/config.ts
@@ -35,9 +35,8 @@ export class S3ModelConfig {
   /**
    * Provide host to bucket
    */
-  get hostName(): string {
-    return `${this.bucket}.s3.amazonaws.com`;
-  }
+  @Required(false)
+  hostName: string;
 
   /**
    * Produces the s3 config from the provide details, post construction
@@ -47,6 +46,14 @@ export class S3ModelConfig {
     if (!Runtime.production) {
       this.endpoint ??= 'http://localhost:4566'; // From docker
       this.bucket ??= 'app';
+    }
+
+    if (!this.hostName) {
+      if (this.endpoint && !this.endpoint.includes('localhost')) {
+        this.hostName = new URL(this.endpoint).host;
+      } else {
+        this.hostName = `${this.bucket}.s3.amazonaws.com`;
+      }
     }
 
     if (!this.accessKeyId && !this.secretAccessKey) {

--- a/module/model-s3/src/service.ts
+++ b/module/model-s3/src/service.ts
@@ -409,7 +409,17 @@ export class S3ModelService implements ModelCrudSupport, ModelBlobSupport, Model
   }
 
   // Signed urls
-  async getBlobReadUrl(location: string, expiresIn: TimeSpan = '1h'): Promise<string> {
+  async getBlobReadUrl(location: string, expiresIn: TimeSpan | false = '1h'): Promise<string> {
+    if (expiresIn === false) {
+      const key = this.#basicKey(location);
+      const host = this.config.hostName;
+      const protocol = this.config.endpoint?.startsWith('http://') ? 'http' : 'https';
+      if (this.config.config.forcePathStyle) {
+        return `${protocol}://${host}/${this.config.bucket}/${key}`;
+      } else {
+        return `${protocol}://${host}/${key}`;
+      }
+    }
     return await getSignedUrl(
       this.client,
       new GetObjectCommand(this.#queryBlob(location)),

--- a/module/model-s3/test/service.ts
+++ b/module/model-s3/test/service.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import { Suite, Test } from '@travetto/test';
 import { BinaryMetadataUtil, BinaryUtil, castTo } from '@travetto/runtime';
 import { S3ModelConfig, S3ModelService } from '@travetto/model-s3';
+import { S3 } from '@aws-sdk/client-s3';
 
 import { ModelBasicSuite } from '@travetto/model/support/test/basic.ts';
 import { ModelCrudSuite } from '@travetto/model/support/test/crud.ts';
@@ -64,5 +65,52 @@ class S3BlobSuite extends ModelBlobSuite {
     assert(buffer.byteLength === blobBytes.byteLength, 'Size mismatch');
     assert(buffer.equals(blobBytes), 'Content mismatch');
     assert(resolved === hash);
+  }
+
+  @Test()
+  async verifyBlobUrls() {
+    // 1. Default hostname
+    const config = new S3ModelConfig();
+    config.bucket = 'my-bucket';
+    await config.finalizeConfig();
+    assert(config.hostName === 'my-bucket.s3.amazonaws.com');
+
+    // 2. Custom hostName configuration
+    const configCustom = new S3ModelConfig();
+    configCustom.bucket = 'my-bucket';
+    configCustom.hostName = 'cdn.example.com';
+    configCustom.endpoint = 'https://cdn.example.com';
+    await configCustom.finalizeConfig();
+    assert(configCustom.hostName === 'cdn.example.com');
+
+    // 3. HostName derived from endpoint
+    const configEndpoint = new S3ModelConfig();
+    configEndpoint.bucket = 'my-bucket';
+    configEndpoint.endpoint = 'https://storage.googleapis.com';
+    await configEndpoint.finalizeConfig();
+    assert(configEndpoint.hostName === 'storage.googleapis.com');
+
+    // 4. getBlobReadUrl with false (returns public URL)
+    const customService = new S3ModelService(configCustom);
+    customService.client = new S3(configCustom.config);
+    const customUrl = await customService.getBlobReadUrl('test-path/file.txt', false);
+    assert(customUrl === 'https://cdn.example.com/test-path/file.txt');
+
+    // 5. getBlobReadUrl with forcePathStyle and false
+    const pathStyleConfig = new S3ModelConfig();
+    pathStyleConfig.bucket = 'my-bucket';
+    pathStyleConfig.endpoint = 'https://storage.googleapis.com';
+    await pathStyleConfig.finalizeConfig();
+    // Simulate setting forcePathStyle to true
+    pathStyleConfig.config.forcePathStyle = true;
+
+    const pathStyleService = new S3ModelService(pathStyleConfig);
+    const pathStyleUrl = await pathStyleService.getBlobReadUrl('test-path/file.txt', false);
+    assert(pathStyleUrl === 'https://storage.googleapis.com/my-bucket/test-path/file.txt');
+
+    // 6. getBlobReadUrl with omitted/default (returns 1h signed URL)
+    const readSignedUrl = await customService.getBlobReadUrl('test-path/file.txt');
+    assert(readSignedUrl.includes('test-path/file.txt?'));
+    assert(readSignedUrl.includes('X-Amz-Expires=3600'));
   }
 }

--- a/module/model/DOC.html
+++ b/module/model/DOC.html
@@ -201,12 +201,13 @@ Some implementations also allow for the ability to read/write binary data as <a 
   <span class="token function">updateBlobMetadata</span><span class="token punctuation">(</span>location<span class="token operator">:</span> <span class="token builtin">string</span><span class="token punctuation">,</span> metadata<span class="token operator">:</span> BinaryMetadata<span class="token punctuation">)</span><span class="token operator">:</span> <span class="token builtin">Promise</span><span class="token operator">&lt;</span><span class="token keyword">void</span><span class="token operator">></span><span class="token punctuation">;</span>
 
   <span class="token comment">/**
-   * Produces an externally usable URL for sharing limited read access to a specific resource
+   * Produces an externally usable URL for sharing limited read access to a specific resource.
+   * If expiresIn is explicitly set to false, returns a direct/public URL.
    *
    * @param location The asset location to read from
-   * @param expiresIn Expiry
+   * @param expiresIn Expiry or false for public/direct URL
    */</span>
-  getBlobReadUrl<span class="token operator">?</span><span class="token punctuation">(</span>location<span class="token operator">:</span> <span class="token builtin">string</span><span class="token punctuation">,</span> expiresIn<span class="token operator">?</span><span class="token operator">:</span> TimeSpan<span class="token punctuation">)</span><span class="token operator">:</span> <span class="token builtin">Promise</span><span class="token operator">&lt;</span><span class="token builtin">string</span><span class="token operator">></span><span class="token punctuation">;</span>
+  getBlobReadUrl<span class="token operator">?</span><span class="token punctuation">(</span>location<span class="token operator">:</span> <span class="token builtin">string</span><span class="token punctuation">,</span> expiresIn<span class="token operator">?</span><span class="token operator">:</span> TimeSpan <span class="token operator">|</span> <span class="token boolean">false</span><span class="token punctuation">)</span><span class="token operator">:</span> <span class="token builtin">Promise</span><span class="token operator">&lt;</span><span class="token builtin">string</span><span class="token operator">></span><span class="token punctuation">;</span>
 
   <span class="token comment">/**
    * Produces an externally usable URL for sharing allowing direct write access
@@ -426,11 +427,11 @@ The module provides the ability to generate an export of the model structure fro
 
 Usage: model:export <span class="token punctuation">[</span>options<span class="token punctuation">]</span> <span class="token operator">&lt;</span>provider:string<span class="token operator">></span> <span class="token operator">&lt;</span>models<span class="token punctuation">..</span>.:string<span class="token operator">></span>
 
-Export model definitions <span class="token keyword">for</span> a selected provider and model set.
+Description:
+  Export model definitions <span class="token keyword">for</span> a selected provider and model set.
 
-The <span class="token builtin class-name">command</span> resolves candidate models and delegates to provider-specific
-<span class="token builtin class-name">export</span> logic to produce schema/install artifacts.
-Example Usage:
+  The <span class="token builtin class-name">command</span> resolves candidate models and delegates to provider-specific
+  <span class="token builtin class-name">export</span> logic to produce schema/install artifacts.
 
 Options:
   -p, <span class="token parameter variable">--profile</span> <span class="token operator">&lt;</span>string<span class="token operator">></span>  Application profiles
@@ -443,7 +444,9 @@ Providers
 
 Models
 --------------------
-  * samplemodel</code></pre>
+  * samplemodel
+
+Examples:</code></pre>
   </figure>
 
 <h2 id="cli-model-install">CLI - model:install</h2>
@@ -458,11 +461,11 @@ The module provides the ability to install all the various <a target="_blank" cl
 
 Usage: model:install <span class="token punctuation">[</span>options<span class="token punctuation">]</span> <span class="token operator">&lt;</span>provider:string<span class="token operator">></span> <span class="token operator">&lt;</span>models<span class="token punctuation">..</span>.:string<span class="token operator">></span>
 
-Install or update model definitions <span class="token keyword">for</span> a selected provider.
+Description:
+  Install or update model definitions <span class="token keyword">for</span> a selected provider.
 
-The <span class="token builtin class-name">command</span> resolves candidate models and applies provider install/upsert
-operations so backing stores are prepared <span class="token keyword">for</span> runtime usage.
-Example Usage:
+  The <span class="token builtin class-name">command</span> resolves candidate models and applies provider install/upsert
+  operations so backing stores are prepared <span class="token keyword">for</span> runtime usage.
 
 Options:
   -p, <span class="token parameter variable">--profile</span> <span class="token operator">&lt;</span>string<span class="token operator">></span>  Application profiles
@@ -475,5 +478,7 @@ Providers
 
 Models
 --------------------
-  * samplemodel</code></pre>
+  * samplemodel
+
+Examples:</code></pre>
   </figure>

--- a/module/model/README.md
+++ b/module/model/README.md
@@ -180,12 +180,13 @@ export interface ModelBlobSupport {
   updateBlobMetadata(location: string, metadata: BinaryMetadata): Promise<void>;
 
   /**
-   * Produces an externally usable URL for sharing limited read access to a specific resource
+   * Produces an externally usable URL for sharing limited read access to a specific resource.
+   * If expiresIn is explicitly set to false, returns a direct/public URL.
    *
    * @param location The asset location to read from
-   * @param expiresIn Expiry
+   * @param expiresIn Expiry or false for public/direct URL
    */
-  getBlobReadUrl?(location: string, expiresIn?: TimeSpan): Promise<string>;
+  getBlobReadUrl?(location: string, expiresIn?: TimeSpan | false): Promise<string>;
 
   /**
    * Produces an externally usable URL for sharing allowing direct write access
@@ -318,11 +319,11 @@ $ trv model:export --help
 
 Usage: model:export [options] <provider:string> <models...:string>
 
-Export model definitions for a selected provider and model set.
+Description:
+  Export model definitions for a selected provider and model set.
 
-The command resolves candidate models and delegates to provider-specific
-export logic to produce schema/install artifacts.
-Example Usage:
+  The command resolves candidate models and delegates to provider-specific
+  export logic to produce schema/install artifacts.
 
 Options:
   -p, --profile <string>  Application profiles
@@ -336,6 +337,8 @@ Providers
 Models
 --------------------
   * samplemodel
+
+Examples:
 ```
 
 ## CLI - model:install
@@ -347,11 +350,11 @@ $ trv model:install --help
 
 Usage: model:install [options] <provider:string> <models...:string>
 
-Install or update model definitions for a selected provider.
+Description:
+  Install or update model definitions for a selected provider.
 
-The command resolves candidate models and applies provider install/upsert
-operations so backing stores are prepared for runtime usage.
-Example Usage:
+  The command resolves candidate models and applies provider install/upsert
+  operations so backing stores are prepared for runtime usage.
 
 Options:
   -p, --profile <string>  Application profiles
@@ -365,4 +368,6 @@ Providers
 Models
 --------------------
   * samplemodel
+
+Examples:
 ```

--- a/module/model/src/types/blob.ts
+++ b/module/model/src/types/blob.ts
@@ -42,12 +42,13 @@ export interface ModelBlobSupport {
   updateBlobMetadata(location: string, metadata: BinaryMetadata): Promise<void>;
 
   /**
-   * Produces an externally usable URL for sharing limited read access to a specific resource
+   * Produces an externally usable URL for sharing limited read access to a specific resource.
+   * If expiresIn is explicitly set to false, returns a direct/public URL.
    *
    * @param location The asset location to read from
-   * @param expiresIn Expiry
+   * @param expiresIn Expiry or false for public/direct URL
    */
-  getBlobReadUrl?(location: string, expiresIn?: TimeSpan): Promise<string>;
+  getBlobReadUrl?(location: string, expiresIn?: TimeSpan | false): Promise<string>;
 
   /**
    * Produces an externally usable URL for sharing allowing direct write access


### PR DESCRIPTION
Resolves the gap in model-s3 to support configurable bucket hostname and retrieving direct public URLs via getBlobReadUrl(..., false).