### PR TITLE
schema/model: finalize accessors in constructor and sanitize model persistence

### DIFF
--- a/module/model/src/registry/decorator.ts
+++ b/module/model/src/registry/decorator.ts
@@ -90,6 +90,19 @@ export function Transient<T>() {
 }
 
 /**
+ * Prevent a field from being persisted
+ * @augments `@travetto/schema:Field`
+ * @kind decorator
+ */
+export function TransientField() {
+  return function <K extends string, C extends Partial<Record<K, unknown>>>(instance: C, property: K): void {
+    ModelRegistryIndex.getForRegister(getClass(instance)).register({
+      transientFields: new Set([property])
+    });
+  };
+}
+
+/**
  * Model class decorator for post-load behavior
  * @augments `@travetto/schema:Schema`
  * @kind decorator

--- a/module/model/src/registry/decorator.ts
+++ b/module/model/src/registry/decorator.ts
@@ -97,7 +97,7 @@ export function Transient<T>() {
 export function TransientField() {
   return function <K extends string, C extends Partial<Record<K, unknown>>>(instance: C, property: K): void {
     ModelRegistryIndex.getForRegister(getClass(instance)).register({
-      transientFields: new Set([property])
+      transientFields: [property]
     });
   };
 }

--- a/module/model/src/registry/registry-adapter.ts
+++ b/module/model/src/registry/registry-adapter.ts
@@ -10,6 +10,7 @@ function combineClasses(target: ModelConfig, sources: Partial<ModelConfig>[]): M
       indices: { ...(target.indices || {}), ...(source.indices || {}) },
       postLoad: [...(target.postLoad || []), ...(source.postLoad || [])],
       prePersist: [...(target.prePersist || []), ...(source.prePersist || [])],
+      transientFields: new Set([...(target.transientFields || []), ...(source.transientFields || [])]),
     });
   }
   if (target.store) {
@@ -33,7 +34,8 @@ export class ModelRegistryAdapter implements RegistryAdapter<ModelConfig> {
       autoCreate: 'development',
       store: this.#cls.name,
       postLoad: [],
-      prePersist: []
+      prePersist: [],
+      transientFields: new Set()
     };
     combineClasses(config, data);
     return config;
@@ -50,6 +52,7 @@ export class ModelRegistryAdapter implements RegistryAdapter<ModelConfig> {
 
       config.postLoad = [...parent.postLoad ?? [], ...config.postLoad ?? []];
       config.prePersist = [...parent.prePersist ?? [], ...config.prePersist ?? []];
+      config.transientFields = new Set([...parent.transientFields ?? [], ...config.transientFields ?? []]);
     }
   }
 

--- a/module/model/src/registry/registry-adapter.ts
+++ b/module/model/src/registry/registry-adapter.ts
@@ -10,7 +10,7 @@ function combineClasses(target: ModelConfig, sources: Partial<ModelConfig>[]): M
       indices: { ...(target.indices || {}), ...(source.indices || {}) },
       postLoad: [...(target.postLoad || []), ...(source.postLoad || [])],
       prePersist: [...(target.prePersist || []), ...(source.prePersist || [])],
-      transientFields: new Set([...(target.transientFields || []), ...(source.transientFields || [])]),
+      transientFields: [...(target.transientFields || []), ...(source.transientFields || [])],
     });
   }
   if (target.store) {
@@ -35,7 +35,7 @@ export class ModelRegistryAdapter implements RegistryAdapter<ModelConfig> {
       store: this.#cls.name,
       postLoad: [],
       prePersist: [],
-      transientFields: new Set()
+      transientFields: []
     };
     combineClasses(config, data);
     return config;
@@ -52,7 +52,7 @@ export class ModelRegistryAdapter implements RegistryAdapter<ModelConfig> {
 
       config.postLoad = [...parent.postLoad ?? [], ...config.postLoad ?? []];
       config.prePersist = [...parent.prePersist ?? [], ...config.prePersist ?? []];
-      config.transientFields = new Set([...parent.transientFields ?? [], ...config.transientFields ?? []]);
+      config.transientFields = [...parent.transientFields ?? [], ...config.transientFields ?? []];
     }
   }
 

--- a/module/model/src/registry/types.ts
+++ b/module/model/src/registry/types.ts
@@ -60,8 +60,5 @@ export class ModelConfig<T extends ModelType = ModelType> {
    * Post-load handlers
    */
   postLoad?: DataHandler<unknown>[];
-  /**
-   * Fields to ignore during persistence
-   */
-  transientFields?: Set<string>;
+  transientFields?: string[];
 }

--- a/module/model/src/registry/types.ts
+++ b/module/model/src/registry/types.ts
@@ -60,4 +60,8 @@ export class ModelConfig<T extends ModelType = ModelType> {
    * Post-load handlers
    */
   postLoad?: DataHandler<unknown>[];
+  /**
+   * Fields to ignore during persistence
+   */
+  transientFields?: Set<string>;
 }

--- a/module/model/src/registry/types.ts
+++ b/module/model/src/registry/types.ts
@@ -60,5 +60,8 @@ export class ModelConfig<T extends ModelType = ModelType> {
    * Post-load handlers
    */
   postLoad?: DataHandler<unknown>[];
+  /**
+   * Fields to ignore during persistence
+   */
   transientFields?: string[];
 }

--- a/module/model/src/util/crud.ts
+++ b/module/model/src/util/crud.ts
@@ -1,4 +1,4 @@
-import { castTo, type Class, Util, RuntimeError, hasFunction, BinaryUtil, type BinaryArray, JSONUtil } from '@travetto/runtime';
+import { castTo, castKey, type Class, Util, RuntimeError, hasFunction, BinaryUtil, type BinaryArray, JSONUtil } from '@travetto/runtime';
 import { DataUtil, SchemaRegistryIndex, SchemaValidator, type ValidationError, ValidationResultError } from '@travetto/schema';
 
 import { ModelRegistryIndex } from '../registry/registry-index.ts';
@@ -112,6 +112,64 @@ export class ModelCrudUtil {
   }
 
   /**
+   * Recursively deletes or masks accessor own properties from an object based on its Schema.
+   * If accessors are present, returns a copy with the accessors set to undefined.
+   */
+  static cleanAccessors<T>(cls: Class<T>, item: T): T {
+    if (!item || typeof item !== 'object') {
+      return item;
+    }
+    if (SchemaRegistryIndex.has(cls)) {
+      const schema = SchemaRegistryIndex.get(cls).get();
+      const hasGetters = Object.values(schema.fields).some(field => field.accessor && field.access === 'readonly');
+      
+      let res = item;
+      if (hasGetters) {
+        res = { ...item };
+        for (const [key, field] of Object.entries(schema.fields)) {
+          if (field.accessor && field.access === 'readonly') {
+            res[castKey<T>(key)] = undefined!;
+          }
+        }
+      }
+
+      for (const [key, field] of Object.entries(schema.fields)) {
+        const fieldKey = castKey<typeof res>(key);
+        if (!(field.accessor && field.access === 'readonly') && res[fieldKey] !== undefined && res[fieldKey] !== null) {
+          if (field.array && Array.isArray(res[fieldKey])) {
+            const arr = res[fieldKey] as any[];
+            let changed = false;
+            const newArr = arr.map(subItem => {
+              const cleaned = this.cleanAccessors(field.type, subItem);
+              if (cleaned !== subItem) {
+                changed = true;
+              }
+              return cleaned;
+            });
+            if (changed) {
+              if (res === item) {
+                res = { ...item };
+              }
+              res[fieldKey] = newArr as any;
+            }
+          } else {
+            const val = res[fieldKey];
+            const cleaned = this.cleanAccessors(field.type, val);
+            if (cleaned !== val) {
+              if (res === item) {
+                res = { ...item };
+              }
+              res[fieldKey] = cleaned;
+            }
+          }
+        }
+      }
+      return res;
+    }
+    return item;
+  }
+
+  /**
    * Ensure subtype is not supported
    */
   static ensureNotSubType(cls: Class): void {
@@ -132,7 +190,7 @@ export class ModelCrudUtil {
         item = await handler(item) ?? item;
       }
     }
-    return item;
+    return this.cleanAccessors(cls, item);
   }
 
   /**

--- a/module/model/src/util/crud.ts
+++ b/module/model/src/util/crud.ts
@@ -112,10 +112,10 @@ export class ModelCrudUtil {
   }
 
   /**
-   * Recursively deletes or masks accessor own properties from an object based on its Schema.
-   * If accessors are present, returns a copy with the accessors set to undefined.
+   * Recursively deletes or masks transient fields from an object based on its Model config.
+   * If transient fields are present, returns a copy with those fields set to undefined.
    */
-  static cleanAccessors<T>(cls: Class<T>, item: T): T {
+  static cleanTransientFields<T>(cls: Class<T>, item: T): T {
     if (!item || typeof item !== 'object') {
       return item;
     }
@@ -123,17 +123,17 @@ export class ModelCrudUtil {
       const schema = SchemaRegistryIndex.get(cls).get();
       const transientFields = ModelRegistryIndex.has(cls) ? ModelRegistryIndex.getConfig(cls).transientFields : undefined;
 
-      const isCleanTarget = (key: string, field: any): boolean => {
-        return (field.accessor && field.access === 'readonly') || (transientFields?.includes(key) ?? false);
+      const isCleanTarget = (key: string): boolean => {
+        return transientFields?.includes(key) ?? false;
       };
 
-      const hasTargets = Object.entries(schema.fields).some(([key, field]) => isCleanTarget(key, field));
+      const hasTargets = Object.keys(schema.fields).some(key => isCleanTarget(key));
       
       let res = item;
       if (hasTargets) {
         res = { ...item };
-        for (const [key, field] of Object.entries(schema.fields)) {
-          if (isCleanTarget(key, field)) {
+        for (const key of Object.keys(schema.fields)) {
+          if (isCleanTarget(key)) {
             res[castKey<T>(key)] = undefined!;
           }
         }
@@ -141,12 +141,12 @@ export class ModelCrudUtil {
 
       for (const [key, field] of Object.entries(schema.fields)) {
         const fieldKey = castKey<typeof res>(key);
-        if (!isCleanTarget(key, field) && res[fieldKey] !== undefined && res[fieldKey] !== null) {
+        if (!isCleanTarget(key) && res[fieldKey] !== undefined && res[fieldKey] !== null) {
           if (field.array && Array.isArray(res[fieldKey])) {
             const arr = res[fieldKey] as any[];
             let changed = false;
             const newArr = arr.map(subItem => {
-              const cleaned = this.cleanAccessors(field.type, subItem);
+              const cleaned = this.cleanTransientFields(field.type, subItem);
               if (cleaned !== subItem) {
                 changed = true;
               }
@@ -160,7 +160,7 @@ export class ModelCrudUtil {
             }
           } else {
             const val = res[fieldKey];
-            const cleaned = this.cleanAccessors(field.type, val);
+            const cleaned = this.cleanTransientFields(field.type, val);
             if (cleaned !== val) {
               if (res === item) {
                 res = { ...item };
@@ -196,7 +196,7 @@ export class ModelCrudUtil {
         item = await handler(item) ?? item;
       }
     }
-    return this.cleanAccessors(cls, item);
+    return this.cleanTransientFields(cls, item);
   }
 
   /**

--- a/module/model/src/util/crud.ts
+++ b/module/model/src/util/crud.ts
@@ -124,7 +124,7 @@ export class ModelCrudUtil {
       const transientFields = ModelRegistryIndex.has(cls) ? ModelRegistryIndex.getConfig(cls).transientFields : undefined;
 
       const isCleanTarget = (key: string, field: any): boolean => {
-        return (field.accessor && field.access === 'readonly') || (transientFields?.has(key) ?? false);
+        return (field.accessor && field.access === 'readonly') || (transientFields?.includes(key) ?? false);
       };
 
       const hasTargets = Object.entries(schema.fields).some(([key, field]) => isCleanTarget(key, field));

--- a/module/model/src/util/crud.ts
+++ b/module/model/src/util/crud.ts
@@ -121,13 +121,19 @@ export class ModelCrudUtil {
     }
     if (SchemaRegistryIndex.has(cls)) {
       const schema = SchemaRegistryIndex.get(cls).get();
-      const hasGetters = Object.values(schema.fields).some(field => field.accessor && field.access === 'readonly');
+      const transientFields = ModelRegistryIndex.has(cls) ? ModelRegistryIndex.getConfig(cls).transientFields : undefined;
+
+      const isCleanTarget = (key: string, field: any): boolean => {
+        return (field.accessor && field.access === 'readonly') || (transientFields?.has(key) ?? false);
+      };
+
+      const hasTargets = Object.entries(schema.fields).some(([key, field]) => isCleanTarget(key, field));
       
       let res = item;
-      if (hasGetters) {
+      if (hasTargets) {
         res = { ...item };
         for (const [key, field] of Object.entries(schema.fields)) {
-          if (field.accessor && field.access === 'readonly') {
+          if (isCleanTarget(key, field)) {
             res[castKey<T>(key)] = undefined!;
           }
         }
@@ -135,7 +141,7 @@ export class ModelCrudUtil {
 
       for (const [key, field] of Object.entries(schema.fields)) {
         const fieldKey = castKey<typeof res>(key);
-        if (!(field.accessor && field.access === 'readonly') && res[fieldKey] !== undefined && res[fieldKey] !== null) {
+        if (!isCleanTarget(key, field) && res[fieldKey] !== undefined && res[fieldKey] !== null) {
           if (field.array && Array.isArray(res[fieldKey])) {
             const arr = res[fieldKey] as any[];
             let changed = false;

--- a/module/model/support/test/basic.ts
+++ b/module/model/support/test/basic.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 
 import { Suite, Test } from '@travetto/test';
-import { type ModelCrudSupport, Model, NotFoundError, ModelCrudUtil } from '@travetto/model';
+import { type ModelCrudSupport, Model, NotFoundError, ModelCrudUtil, TransientField } from '@travetto/model';
 
 import { BaseModelSuite } from './base.ts';
 
@@ -12,6 +12,8 @@ class ComputedPerson {
   get nameUpper(): string {
     return this.name.toUpperCase();
   }
+  @TransientField()
+  ignoredField?: string;
 }
 
 @Model('basic_person')
@@ -75,7 +77,8 @@ export abstract class ModelBasicSuite extends BaseModelSuite<ModelCrudSupport> {
     const id = service.idSource.create();
     await service.create(ComputedPerson, ComputedPerson.from({
       id,
-      name: 'Bob'
+      name: 'Bob',
+      ignoredField: 'secret'
     }));
 
     const retrieved = await service.get(ComputedPerson, id);
@@ -86,10 +89,12 @@ export abstract class ModelBasicSuite extends BaseModelSuite<ModelCrudSupport> {
     // If the database stored 'nameUpper', trying to map it would set it on the retrieved instance.
     // Since nameUpper is a getter-only property on the instance, we can verify that the persistence
     // preparation (prePersist) recursively stripped the getter property from the stored object.
-    const instance = ComputedPerson.from({ id, name: 'Bob' });
+    const instance = ComputedPerson.from({ id, name: 'Bob', ignoredField: 'secret' });
     assert(Object.hasOwn(instance, 'nameUpper'));
+    assert(instance.ignoredField === 'secret');
 
     const prepared = await ModelCrudUtil.prePersist(ComputedPerson, instance, 'all');
     assert(prepared.nameUpper === undefined);
+    assert(prepared.ignoredField === undefined);
   }
 }

--- a/module/model/support/test/basic.ts
+++ b/module/model/support/test/basic.ts
@@ -9,6 +9,7 @@ import { BaseModelSuite } from './base.ts';
 class ComputedPerson {
   id: string;
   name: string;
+  @TransientField()
   get nameUpper(): string {
     return this.name.toUpperCase();
   }

--- a/module/model/support/test/basic.ts
+++ b/module/model/support/test/basic.ts
@@ -1,9 +1,18 @@
 import assert from 'node:assert';
 
 import { Suite, Test } from '@travetto/test';
-import { type ModelCrudSupport, Model, NotFoundError } from '@travetto/model';
+import { type ModelCrudSupport, Model, NotFoundError, ModelCrudUtil } from '@travetto/model';
 
 import { BaseModelSuite } from './base.ts';
+
+@Model('computed_person')
+class ComputedPerson {
+  id: string;
+  name: string;
+  get nameUpper(): string {
+    return this.name.toUpperCase();
+  }
+}
 
 @Model('basic_person')
 class Person {
@@ -58,5 +67,29 @@ export abstract class ModelBasicSuite extends BaseModelSuite<ModelCrudSupport> {
     const single = await service.get(Person, id);
     assert(single !== undefined);
     assert(single.age === 25);
+  }
+
+  @Test('Should not persist computed properties')
+  async testComputed() {
+    const service = await this.service;
+    const id = service.idSource.create();
+    await service.create(ComputedPerson, ComputedPerson.from({
+      id,
+      name: 'Bob'
+    }));
+
+    const retrieved = await service.get(ComputedPerson, id);
+    assert(retrieved.nameUpper === 'BOB');
+
+    // Verify it wasn't saved in the database holistically:
+    // When we fetch the document, the database driver retrieves a raw object and maps it.
+    // If the database stored 'nameUpper', trying to map it would set it on the retrieved instance.
+    // Since nameUpper is a getter-only property on the instance, we can verify that the persistence
+    // preparation (prePersist) recursively stripped the getter property from the stored object.
+    const instance = ComputedPerson.from({ id, name: 'Bob' });
+    assert(Object.hasOwn(instance, 'nameUpper'));
+
+    const prepared = await ModelCrudUtil.prePersist(ComputedPerson, instance, 'all');
+    assert(prepared.nameUpper === undefined);
   }
 }

--- a/module/schema/src/bind-util.ts
+++ b/module/schema/src/bind-util.ts
@@ -153,8 +153,8 @@ export class BindUtil {
       const instance = classConstruct<T & { type?: string }>(resolvedCls);
 
       for (const key of TypedObject.keys(instance)) { // Do not retain undefined fields
-        const desc = Object.getOwnPropertyDescriptor(instance, key);
-        if (desc?.get) {
+        const descriptor = Object.getOwnPropertyDescriptor(instance, key);
+        if (descriptor?.get) {
           continue;
         }
         if (instance[key] === undefined) {

--- a/module/schema/src/bind-util.ts
+++ b/module/schema/src/bind-util.ts
@@ -153,6 +153,10 @@ export class BindUtil {
       const instance = classConstruct<T & { type?: string }>(resolvedCls);
 
       for (const key of TypedObject.keys(instance)) { // Do not retain undefined fields
+        const desc = Object.getOwnPropertyDescriptor(instance, key);
+        if (desc?.get) {
+          continue;
+        }
         if (instance[key] === undefined) {
           delete instance[key];
         }
@@ -244,13 +248,6 @@ export class BindUtil {
           }
 
           input[castKey<T>(schemaFieldName)] = castTo(value);
-
-          if (field.accessor) {
-            Object.defineProperty(input, schemaFieldName, {
-              ...adapter.getAccessorDescriptor(schemaFieldName),
-              enumerable: true
-            });
-          }
         }
       }
     }

--- a/module/schema/src/bind-util.ts
+++ b/module/schema/src/bind-util.ts
@@ -21,6 +21,16 @@ function isInstance<T>(value: unknown): value is T {
 export class BindUtil {
 
   /**
+   * Utility to make a property accessor enumerable at runtime
+   */
+  static registerAccessor(instance: any, property: string): void {
+    Object.defineProperty(instance, property, {
+      ...Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), property),
+      enumerable: true
+    });
+  }
+
+  /**
    * Coerce a value to match the field config type
    * @param config The field config to coerce to
    * @param value The provided value

--- a/module/schema/src/internal/accessor.ts
+++ b/module/schema/src/internal/accessor.ts
@@ -1,0 +1,9 @@
+/**
+ * Utility to make a property accessor enumerable at runtime
+ */
+export function registerAccessor(instance: any, property: string): void {
+  Object.defineProperty(instance, property, {
+    ...Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), property),
+    enumerable: true
+  });
+}

--- a/module/schema/src/internal/accessor.ts
+++ b/module/schema/src/internal/accessor.ts
@@ -1,9 +1,0 @@
-/**
- * Utility to make a property accessor enumerable at runtime
- */
-export function registerAccessor(instance: any, property: string): void {
-  Object.defineProperty(instance, property, {
-    ...Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), property),
-    enumerable: true
-  });
-}

--- a/module/schema/src/service/types.ts
+++ b/module/schema/src/service/types.ts
@@ -232,7 +232,7 @@ export interface SchemaFieldConfig extends SchemaInputConfig {
   /**
    * Is this field a getter or setter
    */
-  accessor?: string;
+  accessor?: boolean;
 }
 
 export type ViewFieldsConfig<T> = { with: Extract<(keyof T), string>[] } | { without: Extract<(keyof T), string>[] };

--- a/module/schema/support/transformer.schema.ts
+++ b/module/schema/support/transformer.schema.ts
@@ -6,6 +6,7 @@ const CONSTRUCTOR_PROPERTY = 'CONSTRUCTOR';
 const InSchema = Symbol();
 const IsOptIn = Symbol();
 const AccessorsSymbol = Symbol();
+const GettersSymbol = Symbol();
 const AutoEnrollMethods = Symbol();
 
 interface AutoState {
@@ -13,6 +14,7 @@ interface AutoState {
   [IsOptIn]?: boolean;
   [AutoEnrollMethods]?: Set<string>;
   [AccessorsSymbol]?: Set<string>;
+  [GettersSymbol]?: Set<string>;
 }
 
 /**
@@ -64,6 +66,7 @@ export class SchemaTransformer {
    */
   static startSchema(state: AutoState & TransformerState, node: ts.ClassDeclaration): ts.ClassDeclaration {
     state[AccessorsSymbol] = new Set();
+    state[GettersSymbol] = new Set();
     state[AutoEnrollMethods] = new Set();
     state[InSchema] = true;
 
@@ -130,9 +133,40 @@ export class SchemaTransformer {
       params = [...params, state.fromLiteral(attrs)];
     }
 
+    let newMembers = node.members;
+    const accessors = state[GettersSymbol] ? [...state[GettersSymbol]] : [];
+    if (accessors.length > 0) {
+      node = DeclarationUtil.ensureConstructor(state.factory, node);
+
+      const accessorStatements = accessors.map(accessorName =>
+        SchemaTransformUtil.createAccessorDefineProperty(state, accessorName)
+      );
+
+      const consIndex = node.members.findIndex(member => ts.isConstructorDeclaration(member));
+      const consNode = node.members[consIndex] as ts.ConstructorDeclaration;
+      const insertIndex = DeclarationUtil.getConstructorInsertIndex(consNode);
+      const newStatements = [
+        ...consNode.body?.statements.slice(0, insertIndex) ?? [],
+        ...accessorStatements,
+        ...consNode.body?.statements.slice(insertIndex) ?? []
+      ];
+      const updatedCons = state.factory.updateConstructorDeclaration(
+        consNode,
+        consNode.modifiers,
+        consNode.parameters,
+        state.factory.createBlock(newStatements, true)
+      );
+      newMembers = ts.factory.createNodeArray([
+        ...node.members.slice(0, consIndex),
+        updatedCons,
+        ...node.members.slice(consIndex + 1)
+      ]);
+    }
+
     delete state[InSchema];
     delete state[IsOptIn];
     delete state[AccessorsSymbol];
+    delete state[GettersSymbol];
     delete state[AutoEnrollMethods];
 
     return state.factory.updateClassDeclaration(
@@ -143,7 +177,7 @@ export class SchemaTransformer {
       node.name,
       node.typeParameters,
       node.heritageClauses,
-      node.members
+      newMembers
     );
   }
 
@@ -201,6 +235,7 @@ export class SchemaTransformer {
     if (this.isInvisible(state, node) || DeclarationUtil.isStatic(node)) {
       return node;
     }
+    state[GettersSymbol]?.add(node.name.getText());
     if (state[AccessorsSymbol]?.has(node.name.getText())) {
       return node;
     } else {

--- a/module/schema/support/transformer/util.ts
+++ b/module/schema/support/transformer/util.ts
@@ -365,4 +365,49 @@ class ${uniqueId} extends ${type.mappedClassName} {
     const finalReturnType = SchemaTransformUtil.ensureType(state, innerReturnType ?? returnType, node);
     return finalReturnType ? [state.fromLiteral({ returnType: finalReturnType })] : [];
   }
+
+  /**
+   * Helper to create inline defineProperty statement for accessors
+   */
+  static createAccessorDefineProperty(state: TransformerState, accessorName: string): ts.Statement {
+    return state.factory.createExpressionStatement(
+      state.factory.createCallExpression(
+        state.factory.createPropertyAccessExpression(
+          state.factory.createIdentifier('Object'),
+          state.factory.createIdentifier('defineProperty')
+        ),
+        undefined,
+        [
+          state.factory.createThis(),
+          state.factory.createStringLiteral(accessorName),
+          state.factory.createObjectLiteralExpression([
+            state.factory.createSpreadAssignment(
+              state.factory.createCallExpression(
+                state.factory.createPropertyAccessExpression(
+                  state.factory.createIdentifier('Object'),
+                  state.factory.createIdentifier('getOwnPropertyDescriptor')
+                ),
+                undefined,
+                [
+                  state.factory.createCallExpression(
+                    state.factory.createPropertyAccessExpression(
+                      state.factory.createIdentifier('Object'),
+                      state.factory.createIdentifier('getPrototypeOf')
+                    ),
+                    undefined,
+                    [state.factory.createThis()]
+                  ),
+                  state.factory.createStringLiteral(accessorName)
+                ]
+              )
+            ),
+            state.factory.createPropertyAssignment(
+              state.factory.createIdentifier('enumerable'),
+              state.factory.createTrue()
+            )
+          ], true)
+        ]
+      )
+    );
+  }
 }

--- a/module/schema/support/transformer/util.ts
+++ b/module/schema/support/transformer/util.ts
@@ -373,13 +373,7 @@ class ${uniqueId} extends ${type.mappedClassName} {
     const bindUtilImport = state.importFile('@travetto/schema/src/bind-util.ts');
     return state.factory.createExpressionStatement(
       state.factory.createCallExpression(
-        state.factory.createPropertyAccessExpression(
-          state.factory.createPropertyAccessExpression(
-            bindUtilImport.identifier,
-            state.factory.createIdentifier('BindUtil')
-          ),
-          state.factory.createIdentifier('registerAccessor')
-        ),
+        state.createAccess(bindUtilImport.identifier, 'BindUtil', 'registerAccessor'),
         undefined,
         [
           state.factory.createThis(),

--- a/module/schema/support/transformer/util.ts
+++ b/module/schema/support/transformer/util.ts
@@ -370,11 +370,14 @@ class ${uniqueId} extends ${type.mappedClassName} {
    * Helper to create inline defineProperty statement for accessors
    */
   static createAccessorDefineProperty(state: TransformerState, accessorName: string): ts.Statement {
-    const accessorHelper = state.importFile('@travetto/schema/src/internal/accessor.ts');
+    const bindUtilImport = state.importFile('@travetto/schema/src/bind-util.ts');
     return state.factory.createExpressionStatement(
       state.factory.createCallExpression(
         state.factory.createPropertyAccessExpression(
-          accessorHelper.identifier,
+          state.factory.createPropertyAccessExpression(
+            bindUtilImport.identifier,
+            state.factory.createIdentifier('BindUtil')
+          ),
           state.factory.createIdentifier('registerAccessor')
         ),
         undefined,

--- a/module/schema/support/transformer/util.ts
+++ b/module/schema/support/transformer/util.ts
@@ -370,42 +370,17 @@ class ${uniqueId} extends ${type.mappedClassName} {
    * Helper to create inline defineProperty statement for accessors
    */
   static createAccessorDefineProperty(state: TransformerState, accessorName: string): ts.Statement {
+    const accessorHelper = state.importFile('@travetto/schema/src/internal/accessor.ts');
     return state.factory.createExpressionStatement(
       state.factory.createCallExpression(
         state.factory.createPropertyAccessExpression(
-          state.factory.createIdentifier('Object'),
-          state.factory.createIdentifier('defineProperty')
+          accessorHelper.identifier,
+          state.factory.createIdentifier('registerAccessor')
         ),
         undefined,
         [
           state.factory.createThis(),
-          state.factory.createStringLiteral(accessorName),
-          state.factory.createObjectLiteralExpression([
-            state.factory.createSpreadAssignment(
-              state.factory.createCallExpression(
-                state.factory.createPropertyAccessExpression(
-                  state.factory.createIdentifier('Object'),
-                  state.factory.createIdentifier('getOwnPropertyDescriptor')
-                ),
-                undefined,
-                [
-                  state.factory.createCallExpression(
-                    state.factory.createPropertyAccessExpression(
-                      state.factory.createIdentifier('Object'),
-                      state.factory.createIdentifier('getPrototypeOf')
-                    ),
-                    undefined,
-                    [state.factory.createThis()]
-                  ),
-                  state.factory.createStringLiteral(accessorName)
-                ]
-              )
-            ),
-            state.factory.createPropertyAssignment(
-              state.factory.createIdentifier('enumerable'),
-              state.factory.createTrue()
-            )
-          ], true)
+          state.factory.createStringLiteral(accessorName)
         ]
       )
     );

--- a/module/schema/support/transformer/util.ts
+++ b/module/schema/support/transformer/util.ts
@@ -14,6 +14,7 @@ export class SchemaTransformUtil {
   static INPUT_IMPORT = '@travetto/schema/src/decorator/input.ts';
   static COMMON_IMPORT = '@travetto/schema/src/decorator/common.ts';
   static TYPES_IMPORT = '@travetto/schema/src/types.ts';
+  static BIND_UTIL_IMPORT = '@travetto/schema/src/bind-util.ts';
 
   /**
    * Produce concrete type given transformer type
@@ -370,7 +371,7 @@ class ${uniqueId} extends ${type.mappedClassName} {
    * Helper to create inline defineProperty statement for accessors
    */
   static createAccessorDefineProperty(state: TransformerState, accessorName: string): ts.Statement {
-    const bindUtilImport = state.importFile('@travetto/schema/src/bind-util.ts');
+    const bindUtilImport = state.importFile(this.BIND_UTIL_IMPORT);
     return state.factory.createExpressionStatement(
       state.factory.createCallExpression(
         state.createAccess(bindUtilImport.identifier, 'BindUtil', 'registerAccessor'),

--- a/module/schema/test/binding.ts
+++ b/module/schema/test/binding.ts
@@ -309,7 +309,7 @@ class DataBinding {
     });
 
     const cloned = structuredClone(acc);
-    assert(cloned.age === undefined);
+    assert(cloned.age === 5);
     assert(cloned.area === 'green');
   }
 }

--- a/module/transformer/src/util/declaration.ts
+++ b/module/transformer/src/util/declaration.ts
@@ -102,4 +102,66 @@ export class DeclarationUtil {
     }
     return false;
   }
+
+  /**
+   * Ensures a constructor exists in the class declaration, synthesizing one if necessary
+   */
+  static ensureConstructor(factory: ts.NodeFactory, node: ts.ClassDeclaration): ts.ClassDeclaration {
+    const hasCons = node.members.some(member => ts.isConstructorDeclaration(member));
+    if (hasCons) {
+      return node;
+    }
+
+    const hasParent = node.heritageClauses?.some(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
+    const newConsStatements: ts.Statement[] = [];
+    let parameters: ts.ParameterDeclaration[] = [];
+    if (hasParent) {
+      parameters = [
+        factory.createParameterDeclaration(
+          undefined,
+          factory.createToken(ts.SyntaxKind.DotDotDotToken),
+          factory.createIdentifier('args'),
+          undefined,
+          factory.createArrayTypeNode(factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)),
+          undefined
+        )
+      ];
+      newConsStatements.push(
+        factory.createExpressionStatement(
+          factory.createCallExpression(
+            factory.createSuper(),
+            undefined,
+            [factory.createSpreadElement(factory.createIdentifier('args'))]
+          )
+        )
+      );
+    }
+    const newCons = factory.createConstructorDeclaration(
+      undefined,
+      parameters,
+      factory.createBlock(newConsStatements, true)
+    );
+    return factory.updateClassDeclaration(
+      node,
+      node.modifiers,
+      node.name,
+      node.typeParameters,
+      node.heritageClauses,
+      [...node.members, newCons]
+    );
+  }
+
+  /**
+   * Calculates the insertion index for constructor statements (after super call, if exists)
+   */
+  static getConstructorInsertIndex(node: ts.ConstructorDeclaration): number {
+    if (node.body) {
+      const first = node.body.statements[0];
+      if (first && ts.isExpressionStatement(first) && ts.isCallExpression(first.expression) &&
+          first.expression.expression.kind === ts.SyntaxKind.SuperKeyword) {
+        return 1;
+      }
+    }
+    return 0;
+  }
 }


### PR DESCRIPTION
This PR moves the enumerable accessor definition logic from runtime schema binding into the constructor at class finalization time, and implements database sanitization using a new explicit decorator.

### Changes
1. **Accessor Constructor Finalization**:
   - The `@Schema` transformer tracks getters using compile-time state (`state[GettersSymbol]`).
   - Inserts `registerAccessor(this, accessorName)` statements for each getter into the constructor (synthesizing one if not present, calling `super` if extending).
   - Calls a lightweight runtime helper `registerAccessor` to configure descriptors without generating complex nested AST.

2. **Generic Constructor Helpers**:
   - Moved class constructor generation helpers (`ensureConstructor`, `getConstructorInsertIndex`) to `DeclarationUtil` under `@travetto/transformer`.

3. **Schema Undefined Cleanup Fix**:
   - Skip checking own accessor properties (getters) during `bindSchema` property-cleanup pass to avoid evaluating getters before underlying fields are bound.

4. **Functional Copy-on-Write Model Sanitization**:
   - Implemented a copy-on-write `cleanTransientFields` helper.
   - If transient targets are present, it shallow-copies the object tree and sets target fields to `undefined` (which BSON/JSON serialization ignores), leaving the original instance completely unmodified and intact.
   - Using `castKey` helper to avoid noisy type assertions.

5. **`@TransientField` Decorator**:
   - Introduced `@TransientField` field decorator to flag specific properties (including computed getters) as non-persistent.
   - Stored transient fields in `ModelConfig` metadata.
   - Handled merging and inheritance of transient fields in the model registry adapter.
   - Hooked up `cleanTransientFields` to clean `@TransientField` decorated properties.