### PR TITLE
feat(model): replace ExistsError with UniqueError for unique constraint violations

### DIFF
--- a/global-test/model_auth-model/package.json
+++ b/global-test/model_auth-model/package.json
@@ -8,11 +8,11 @@
     "@travetto/model-elasticsearch": "^8.0.0-alpha.25",
     "@travetto/model-firestore": "^8.0.0-alpha.29",
     "@travetto/model-mongo": "^8.0.0-alpha.25",
-    "@travetto/model-mysql": "^8.0.0-alpha.25",
-    "@travetto/model-postgres": "^8.0.0-alpha.25",
+    "@travetto/model-mysql": "^8.0.0-alpha.26",
+    "@travetto/model-postgres": "^8.0.0-alpha.26",
     "@travetto/model-redis": "^8.0.0-alpha.25",
     "@travetto/model-s3": "^8.0.0-alpha.24",
-    "@travetto/model-sqlite": "^8.0.0-alpha.25"
+    "@travetto/model-sqlite": "^8.0.0-alpha.26"
   },
   "travetto": {},
   "private": true

--- a/global-test/model_auth-session/package.json
+++ b/global-test/model_auth-session/package.json
@@ -8,11 +8,11 @@
     "@travetto/model-elasticsearch": "^8.0.0-alpha.25",
     "@travetto/model-firestore": "^8.0.0-alpha.29",
     "@travetto/model-mongo": "^8.0.0-alpha.25",
-    "@travetto/model-mysql": "^8.0.0-alpha.25",
-    "@travetto/model-postgres": "^8.0.0-alpha.25",
+    "@travetto/model-mysql": "^8.0.0-alpha.26",
+    "@travetto/model-postgres": "^8.0.0-alpha.26",
     "@travetto/model-redis": "^8.0.0-alpha.25",
     "@travetto/model-s3": "^8.0.0-alpha.24",
-    "@travetto/model-sqlite": "^8.0.0-alpha.25"
+    "@travetto/model-sqlite": "^8.0.0-alpha.26"
   },
   "travetto": {},
   "private": true

--- a/global-test/model_cache/package.json
+++ b/global-test/model_cache/package.json
@@ -8,11 +8,11 @@
     "@travetto/model-elasticsearch": "^8.0.0-alpha.25",
     "@travetto/model-firestore": "^8.0.0-alpha.29",
     "@travetto/model-mongo": "^8.0.0-alpha.25",
-    "@travetto/model-mysql": "^8.0.0-alpha.25",
-    "@travetto/model-postgres": "^8.0.0-alpha.25",
+    "@travetto/model-mysql": "^8.0.0-alpha.26",
+    "@travetto/model-postgres": "^8.0.0-alpha.26",
     "@travetto/model-redis": "^8.0.0-alpha.25",
     "@travetto/model-s3": "^8.0.0-alpha.24",
-    "@travetto/model-sqlite": "^8.0.0-alpha.25"
+    "@travetto/model-sqlite": "^8.0.0-alpha.26"
   },
   "travetto": {},
   "private": true

--- a/module/model-indexed/support/test/indexed.ts
+++ b/module/model-indexed/support/test/indexed.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import timers from 'node:timers/promises';
 
-import { ExistsError, ModelBulkUtil, NotFoundError } from '@travetto/model';
+import { ModelBulkUtil, NotFoundError, UniqueError } from '@travetto/model';
 import { castTo, TimeUtil } from '@travetto/runtime';
 import { Suite, Test } from '@travetto/test';
 
@@ -77,7 +77,7 @@ export abstract class ModelIndexedSuite extends BaseModelSuite<ModelIndexedSuppo
 
     await assert.rejects(
       () => service.create(UniqueUser, UniqueUser.from({ name: 'sam' })),
-      err => err instanceof ExistsError
+      err => err instanceof UniqueError
     );
 
     const found = await service.getByIndex(UniqueUser, userUniqueNameIndex, { name: 'sam' });

--- a/module/model-mongo/src/service.ts
+++ b/module/model-mongo/src/service.ts
@@ -31,7 +31,8 @@ import {
   ModelStorageUtil,
   type ModelType,
   NotFoundError,
-  type OptionalId
+  type OptionalId,
+  UniqueError
 } from '@travetto/model';
 import {
   type FullKeyedIndexBody,
@@ -85,7 +86,17 @@ type BlobRaw = GridFSFile & { metadata?: BinaryMetadata };
 
 type MongoTextSearch = RootFilterOperators<unknown>['$text'];
 
-const isDuplicateKeyError = (error: unknown): boolean => error instanceof MongoServerError && error.message.includes('duplicate key error');
+const handleDuplicateKeyError = (cls: Class, id: string, error: unknown): unknown => {
+  if (error instanceof MongoServerError && error.message.includes('duplicate key error')) {
+    if (error.message.includes('_id_') || (error.keyPattern && '_id' in error.keyPattern)) {
+      return new ExistsError(cls, id);
+    }
+    const match = error.message.match(/index: ([\w$]+)/);
+    const constraint = match ? match[1] : error.keyPattern ? Object.keys(error.keyPattern).join(',') : 'unique';
+    return new UniqueError(cls, constraint, { detail: error.message });
+  }
+  return error;
+};
 
 export const ModelBlobNamespace = '__blobs';
 
@@ -312,7 +323,7 @@ export class MongoModelService
       }
       return this.postUpdate(cleaned, id);
     } catch (error) {
-      throw isDuplicateKeyError(error) ? new ExistsError(cls, id) : error;
+      throw handleDuplicateKeyError(cls, id, error);
     }
   }
 
@@ -335,7 +346,7 @@ export class MongoModelService
     try {
       await store.updateOne(this.getIdFilter(cls, id, false), { $set: cleaned }, { upsert: true });
     } catch (error) {
-      throw isDuplicateKeyError(error) ? new ExistsError(cls, id) : error;
+      throw handleDuplicateKeyError(cls, id, error);
     }
     return this.postUpdate(cleaned, id);
   }

--- a/module/model-mysql/package.json
+++ b/module/model-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travetto/model-mysql",
-  "version": "8.0.0-alpha.25",
+  "version": "8.0.0-alpha.26",
   "type": "module",
   "description": "MySQL backing for the travetto model module, with real-time modeling support for SQL schemas.",
   "keywords": [
@@ -32,7 +32,7 @@
     "@travetto/context": "^8.0.0-alpha.20",
     "@travetto/model": "^8.0.0-alpha.23",
     "@travetto/model-query": "^8.0.0-alpha.24",
-    "@travetto/model-sql": "^8.0.0-alpha.25",
+    "@travetto/model-sql": "^8.0.0-alpha.26",
     "mysql2": "^3.22.6"
   },
   "peerDependencies": {

--- a/module/model-mysql/src/connection.ts
+++ b/module/model-mysql/src/connection.ts
@@ -3,7 +3,7 @@ import type { OkPacket, Pool, PoolConnection, ResultSetHeader, TypeCastField } f
 
 import type { AsyncContext } from '@travetto/context';
 import { Injectable } from '@travetto/di';
-import { ExistsError, type ModelType } from '@travetto/model';
+import { ExistsError, type ModelType, UniqueError } from '@travetto/model';
 import { SQLConnection, type TableContext } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil, ShutdownManager } from '@travetto/runtime';
 
@@ -113,8 +113,12 @@ export class MysqlConnection extends SQLConnection<PoolConnection> {
     } catch (error) {
       const code = error && typeof error === 'object' && 'code' in error ? error.code : undefined;
       switch (code) {
-        case 'ER_DUP_ENTRY':
-          throw new ExistsError('query', query);
+        case 'ER_DUP_ENTRY': {
+          const message = error instanceof Error ? error.message : '';
+          const match = message.match(/for key '([^']+)'/);
+          const key = match ? match[1] : 'query';
+          throw new UniqueError('query', key, { message, query });
+        }
         case 'ER_DUP_KEYNAME':
           throw new ExistsError('index', query);
         default:

--- a/module/model-postgres/package.json
+++ b/module/model-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travetto/model-postgres",
-  "version": "8.0.0-alpha.25",
+  "version": "8.0.0-alpha.26",
   "type": "module",
   "description": "PostgreSQL backing for the travetto model module, with real-time modeling support for SQL schemas.",
   "keywords": [
@@ -32,7 +32,7 @@
     "@travetto/context": "^8.0.0-alpha.20",
     "@travetto/model": "^8.0.0-alpha.23",
     "@travetto/model-query": "^8.0.0-alpha.24",
-    "@travetto/model-sql": "^8.0.0-alpha.25",
+    "@travetto/model-sql": "^8.0.0-alpha.26",
     "@types/pg": "^8.20.0",
     "pg": "^8.22.0"
   },

--- a/module/model-postgres/src/connection.ts
+++ b/module/model-postgres/src/connection.ts
@@ -1,13 +1,17 @@
-import { type Pool, type PoolClient, default as pg } from 'pg';
+import { type DatabaseError, type Pool, type PoolClient, default as pg } from 'pg';
 
 import type { AsyncContext } from '@travetto/context';
 import { Injectable } from '@travetto/di';
-import { ExistsError } from '@travetto/model';
+import { ExistsError, UniqueError } from '@travetto/model';
 import { SQLConnection } from '@travetto/model-sql';
 import { castTo, ShutdownManager } from '@travetto/runtime';
 
 import type { PostgresModelConfig } from './config.ts';
 import { PostgresDialect } from './dialect.ts';
+
+function isPgDatabaseError(error: unknown): error is DatabaseError {
+  return !!error && typeof error === 'object' && 'code' in error;
+}
 
 /**
  * PostgreSQL connection manager
@@ -86,15 +90,16 @@ export class PostgresConnection extends SQLConnection<PoolClient> {
       const records: Type[] = [...result.rows].map(row => ({ ...row }));
       return { count: result.rowCount ?? 0, records };
     } catch (error) {
-      const code = error && typeof error === 'object' && 'code' in error ? castTo<Record<string, unknown>>(error).code : undefined;
-      switch (code) {
-        case '42P07':
+      if (isPgDatabaseError(error)) {
+        if (error.code === '23505') {
+          const constraint = error.constraint ?? (error.detail ? 'index' : 'query');
+          const detail = error.detail ?? query;
+          throw new UniqueError('index', constraint, { detail, query });
+        } else if (error.code === '42P07') {
           throw new ExistsError('index', query);
-        case '23505':
-          throw new ExistsError('query', query);
-        default:
-          throw error;
+        }
       }
+      throw error;
     }
   }
 }

--- a/module/model-query/src/model/where-clause.ts
+++ b/module/model-query/src/model/where-clause.ts
@@ -45,7 +45,7 @@ type GeoField = {
 };
 
 export type PropWhereClause<T> = {
-  [P in keyof T]?: T[P] extends number | undefined
+  -readonly [P in keyof T]?: T[P] extends number | undefined
     ? General<number> | ScalarField<number> | ComparableField<number> | number
     : T[P] extends bigint | undefined
       ? General<bigint> | ScalarField<bigint> | ComparableField<bigint> | bigint

--- a/module/model-query/support/test/crud.ts
+++ b/module/model-query/support/test/crud.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { ExistsError, Model, type ModelCrudSupport, NotFoundError } from '@travetto/model';
+import { Model, type ModelCrudSupport, NotFoundError, UniqueError } from '@travetto/model';
 import { castTo } from '@travetto/runtime';
 import { Suite, Test } from '@travetto/test';
 
@@ -29,7 +29,7 @@ export abstract class ModelQueryCrudSuite extends BaseModelSuite<ModelQueryCrudS
   async testUnique() {
     const svc = await this.service;
     await svc.create(UniqueUser2, UniqueUser2.from({ name: 'bob' }));
-    await assert.rejects(() => svc.create(UniqueUser2, UniqueUser2.from({ name: 'bob' })), ExistsError);
+    await assert.rejects(() => svc.create(UniqueUser2, UniqueUser2.from({ name: 'bob' })), UniqueError);
   }
 
   @Test()

--- a/module/model-sql/package.json
+++ b/module/model-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travetto/model-sql",
-  "version": "8.0.0-alpha.25",
+  "version": "8.0.0-alpha.26",
   "type": "module",
   "description": "SQL backing for the travetto model module, with real-time modeling support for SQL schemas.",
   "keywords": [

--- a/module/model-sql/src/service.ts
+++ b/module/model-sql/src/service.ts
@@ -15,7 +15,8 @@ import {
   type ModelStorageSupport,
   type ModelType,
   NotFoundError,
-  type OptionalId
+  type OptionalId,
+  UniqueError
 } from '@travetto/model';
 import {
   type FullKeyedIndexBody,
@@ -207,7 +208,14 @@ export abstract class BaseSQLModelService<C = unknown>
 
     const { sql, values } = this.dialect.buildInsert(tableContext, rawItem);
 
-    await this.connection.execute(sql, values);
+    try {
+      await this.connection.execute(sql, values);
+    } catch (error) {
+      if (error instanceof UniqueError && (error.details?.type === 'query' || error.details?.type === 'index')) {
+        throw new UniqueError(modelClass, (error.details.constraint as string) ?? 'unknown', error.details);
+      }
+      throw error;
+    }
     return preppedItem;
   }
 

--- a/module/model-sqlite/package.json
+++ b/module/model-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@travetto/model-sqlite",
-  "version": "8.0.0-alpha.25",
+  "version": "8.0.0-alpha.26",
   "type": "module",
   "description": "SQLite backing for the travetto model module, with real-time modeling support for SQL schemas.",
   "keywords": [
@@ -31,7 +31,7 @@
     "@travetto/context": "^8.0.0-alpha.20",
     "@travetto/model": "^8.0.0-alpha.23",
     "@travetto/model-query": "^8.0.0-alpha.24",
-    "@travetto/model-sql": "^8.0.0-alpha.25"
+    "@travetto/model-sql": "^8.0.0-alpha.26"
   },
   "travetto": {
     "displayName": "SQLite Model Service"

--- a/module/model-sqlite/src/connection.ts
+++ b/module/model-sqlite/src/connection.ts
@@ -6,7 +6,7 @@ import { createPool, type Pool } from 'generic-pool';
 
 import type { AsyncContext } from '@travetto/context';
 import { Injectable } from '@travetto/di';
-import { ExistsError } from '@travetto/model';
+import { ExistsError, UniqueError } from '@travetto/model';
 import { SQLConnection } from '@travetto/model-sql';
 import { castTo, JSONUtil, Runtime, RuntimeError, ShutdownManager, Util } from '@travetto/runtime';
 
@@ -176,13 +176,19 @@ export class SqliteConnection extends SQLConnection<DatabaseSync> {
         switch (code) {
           case 'ERR_SQLITE_ERROR': {
             if (message?.startsWith('UNIQUE')) {
-              throw new ExistsError('query', query);
+              const match = message.match(/UNIQUE constraint failed: (.*)/);
+              const key = match ? match[1] : 'query';
+              throw new UniqueError('query', key, { message, query });
             }
             break;
           }
-          case 'SQLITE_CONSTRAINT_PRIMARYKEY':
           case 'SQLITE_CONSTRAINT_UNIQUE':
-          case 'SQLITE_CONSTRAINT_INDEX':
+          case 'SQLITE_CONSTRAINT_INDEX': {
+            const match = message?.match(/UNIQUE constraint failed: (.*)/);
+            const key = match ? match[1] : 'query';
+            throw new UniqueError('query', key, { message, query });
+          }
+          case 'SQLITE_CONSTRAINT_PRIMARYKEY':
             throw new ExistsError('query', query);
         }
         if (/index.*?already exists/.test(message ?? '')) {

--- a/module/model/__index__.ts
+++ b/module/model/__index__.ts
@@ -2,6 +2,7 @@ export * from './src/error/exists.ts';
 export * from './src/error/invalid-index.ts';
 export * from './src/error/invalid-sub-type.ts';
 export * from './src/error/not-found.ts';
+export * from './src/error/unique.ts';
 export * from './src/registry/decorator.ts';
 export * from './src/registry/registry-adapter.ts';
 export * from './src/registry/registry-index.ts';

--- a/module/model/src/error/unique.ts
+++ b/module/model/src/error/unique.ts
@@ -1,0 +1,13 @@
+import { type Class, RuntimeError } from '@travetto/runtime';
+
+/**
+ * Represents when a data item violates a unique constraint or index
+ */
+export class UniqueError extends RuntimeError {
+  constructor(cls: Class | string, constraint: string, details: Record<string, unknown> = {}) {
+    super(`${typeof cls === 'string' ? cls : cls.name} violates unique constraint on ${constraint}`, {
+      category: 'data',
+      details: { constraint, type: typeof cls === 'string' ? cls : cls.name, ...details }
+    });
+  }
+}


### PR DESCRIPTION
### Summary of Changes

- Introduced `UniqueError` class in `@travetto/model` to represent unique constraint and index violations with detailed information about the violated constraint or field.
- Updated SQL connection implementations (`PostgresConnection`, `MysqlConnection`, `SqliteConnection`) and `SQLModelService` to throw `UniqueError` on duplicate key / unique constraint failures instead of generic `ExistsError`.
- Updated `MongoModelService` to distinguish primary key (`_id`) collisions from secondary unique index violations, throwing `UniqueError` for unique index constraints.
- Updated `@travetto/model-query` and `@travetto/model-indexed` test suites to assert `UniqueError` for unique index tests.