### PR TITLE
feat(model-sql): support nested array property queries across SQL dialects

### DIFF
--- a/module/cache/support/test/service.ts
+++ b/module/cache/support/test/service.ts
@@ -223,14 +223,14 @@ export abstract class CacheServiceSuite {
     const service = this.testService;
 
     // Prime cache
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       const start = Date.now();
       await service.getUser(`${i}`);
       assert(Date.now() - start >= 100);
     }
 
     // Read cache
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       const start = Date.now();
       await service.getUser(`${i}`);
       assert(Date.now() - start <= this.baseLatency + 100);
@@ -239,14 +239,14 @@ export abstract class CacheServiceSuite {
     await service.deleteAllUsers();
 
     // Prime cache
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       const start = Date.now();
       await service.getUser(`${i}`);
       assert(Date.now() - start >= 100);
     }
 
     // Read cache
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 10; i += 1) {
       const start = Date.now();
       await service.getUser(`${i}`);
       assert(Date.now() - start <= this.baseLatency + 100);

--- a/module/compiler/src/util.ts
+++ b/module/compiler/src/util.ts
@@ -38,7 +38,7 @@ export class CompilerUtil {
   static naiveHash(text: string): number {
     let hash = 5381;
 
-    for (let i = 0; i < text.length; i++) {
+    for (let i = 0; i < text.length; i += 1) {
       hash = (hash * 33) ^ text.charCodeAt(i);
     }
 

--- a/module/config/src/parser/properties.ts
+++ b/module/config/src/parser/properties.ts
@@ -39,7 +39,7 @@ export class PropertiesConfigParser implements ConfigParser {
     const out: ConfigData = {};
     const lines = text.split(/\n/g);
 
-    for (let i = 0; i < lines.length; i++) {
+    for (let i = 0; i < lines.length; i += 1) {
       let line = lines[i];
       while (i < lines.length && line.endsWith('\\')) {
         line = `${line.replace(/[\\]$/, '')}${lines[(i += 1)].trimStart()}`;

--- a/module/config/src/source/file.ts
+++ b/module/config/src/source/file.ts
@@ -46,7 +46,7 @@ export class FileConfigSource implements ConfigSource {
         for (const file of files) {
           if (this.#parser.matches(file) && path.basename(file, path.extname(file)) === profile) {
             const full = path.resolve(folder, file);
-            const configPriority = i++;
+            const configPriority = (i += 1);
             configs.push(
               this.#parser.parse(full).then(data => ({
                 data,

--- a/module/model-elasticsearch/src/internal/query.ts
+++ b/module/model-elasticsearch/src/internal/query.ts
@@ -109,7 +109,7 @@ export class ElasticsearchQueryUtil {
         const subKey = Object.keys(top)[0];
         if (!subKey.startsWith('$')) {
           const inner = this.extractWhereTermQuery(declaredType, top, config, `${subPath}.`);
-          items.push(declaredSchema.array ? (this.hasNestedClause(inner) ? inner : { nested: { path: subPath, query: inner } }) : inner);
+          items.push(!declaredSchema.array || this.hasNestedClause(inner) ? inner : { nested: { path: subPath, query: inner } });
         } else {
           const value = top[subKey];
 

--- a/module/model-elasticsearch/src/internal/query.ts
+++ b/module/model-elasticsearch/src/internal/query.ts
@@ -67,6 +67,22 @@ export class ElasticsearchQueryUtil {
   }
 
   /**
+   * Type guard to check if a query object contains a nested clause
+   */
+  static hasNestedClause(query: Record<string, unknown>): boolean {
+    if ('nested' in query) {
+      return true;
+    }
+    if ('bool' in query && DataUtil.isPlainObject(query.bool)) {
+      const boolQuery = query.bool as { must?: unknown[] };
+      if (Array.isArray(boolQuery.must)) {
+        return boolQuery.must.some(element => DataUtil.isPlainObject(element) && this.hasNestedClause(element as Record<string, unknown>));
+      }
+    }
+    return false;
+  }
+
+  /**
    * Extract specific term for a class, and a given field
    */
   static extractWhereTermQuery<T>(
@@ -93,18 +109,28 @@ export class ElasticsearchQueryUtil {
         const subKey = Object.keys(top)[0];
         if (!subKey.startsWith('$')) {
           const inner = this.extractWhereTermQuery(declaredType, top, config, `${subPath}.`);
-          items.push(declaredSchema.array ? { nested: { path: subPath, query: inner } } : inner);
+          items.push(declaredSchema.array ? (this.hasNestedClause(inner) ? inner : { nested: { path: subPath, query: inner } }) : inner);
         } else {
           const value = top[subKey];
 
           switch (subKey) {
             case '$all': {
               const values = Array.isArray(value) ? value : [value];
-              items.push({
-                bool: {
-                  must: values.map(term => ({ term: { [subPath]: term } }))
-                }
-              });
+              const terms = values.map(term => ({ term: { [subPath]: term } }));
+              if (path) {
+                const nestedPath = path.replace(/\.$/, '');
+                items.push({
+                  bool: {
+                    must: terms.map(query => ({ nested: { path: nestedPath, query } }))
+                  }
+                });
+              } else {
+                items.push({
+                  bool: {
+                    must: terms
+                  }
+                });
+              }
               break;
             }
             case '$in': {

--- a/module/model-elasticsearch/src/service.ts
+++ b/module/model-elasticsearch/src/service.ts
@@ -429,7 +429,7 @@ export class ElasticsearchModelService
 
     type CountProperty = keyof (typeof out)['counts'];
 
-    for (let i = 0; i < result.items.length; i++) {
+    for (let i = 0; i < result.items.length; i += 1) {
       const item = result.items[i];
       const [key] = TypedObject.keys(item);
       const responseItem = item[key]!;

--- a/module/model-memory/src/service.ts
+++ b/module/model-memory/src/service.ts
@@ -14,7 +14,8 @@ import {
   ModelStorageUtil,
   type ModelType,
   NotFoundError,
-  type OptionalId
+  type OptionalId,
+  UniqueError
 } from '@travetto/model';
 import {
   type AllIndexes,
@@ -151,7 +152,7 @@ export class MemoryModelService
           if (idx.unique) {
             const existing = this.#indices[idx.type].get(idxName)?.get(key);
             if (existing && existing.size > 0 && !existing.has(item.id)) {
-              throw new ExistsError(cls, key);
+              throw new UniqueError(cls, key);
             }
           }
           this.#indices[idx.type].getOrInsert(idxName, new Map()).getOrInsert(key, new Set()).add(item.id);

--- a/module/model-mongo/src/internal/util.ts
+++ b/module/model-mongo/src/internal/util.ts
@@ -265,7 +265,7 @@ export class MongoUtil {
     const overlap = [...pendingKeySet.intersection(existingKeySet)];
     changed ||= overlap.length !== pendingKeySet.size;
 
-    for (let i = 0; i < overlap.length && !changed; i++) {
+    for (let i = 0; i < overlap.length && !changed; i += 1) {
       changed ||= existingFields[overlap[i]] !== pendingKey[overlap[i]];
     }
 

--- a/module/model-mysql/src/dialect.ts
+++ b/module/model-mysql/src/dialect.ts
@@ -64,9 +64,9 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     }
   }
 
-  #getArraySqlPath(sqlPath: string, context?: ResolvedPathContext): string {
-    if (!context?.arrayPath || context.arrayPath.length === 0 || !context.subPath || context.subPath.length === 0) {
-      return sqlPath;
+  #getArraySqlPath(context: ResolvedPathContext): string {
+    if (!context.arrayPath || context.arrayPath.length === 0 || !context.subPath || context.subPath.length === 0) {
+      return context.sqlPath;
     }
     const columnName = this.escapeIdentifier(context.arrayPath[0]);
     const arrayPathPart = context.arrayPath.length > 1 ? context.arrayPath.slice(1).join('.') : '';
@@ -74,51 +74,24 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     return `JSON_EXTRACT(${columnName}, '${jsonPathExpr}')`;
   }
 
-  compileArrayAll(
-    sqlPath: string,
-    identifier: string,
-    value: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+  compileArrayAll(context: ResolvedPathContext, identifier: string, value: unknown[]): { sql: string; formatted: unknown } {
+    const targetSqlPath = this.#getArraySqlPath(context);
     return { sql: `JSON_CONTAINS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(value) };
   }
 
-  compileArrayEquals(
-    sqlPath: string,
-    identifier: string,
-    values: unknown,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
-    const val = context?.subPath?.length && !Array.isArray(values) ? [values] : values;
+  compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown): { sql: string; formatted: unknown } {
+    const targetSqlPath = this.#getArraySqlPath(context);
+    const val = context.subPath?.length && !Array.isArray(values) ? [values] : values;
     return { sql: `JSON_CONTAINS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(val) };
   }
 
-  compileArrayAny(
-    sqlPath: string,
-    identifier: string,
-    values: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+  compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]): { sql: string; formatted: unknown } {
+    const targetSqlPath = this.#getArraySqlPath(context);
     return { sql: `JSON_OVERLAPS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(values) };
   }
 
-  compileArrayExists(
-    sqlPath: string,
-    identifier: string,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string } {
-    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+  compileArrayExists(context: ResolvedPathContext, identifier?: string): { sql: string } {
+    const targetSqlPath = this.#getArraySqlPath(context);
     return { sql: `(${targetSqlPath} IS NOT NULL AND JSON_LENGTH(${targetSqlPath}) > 0)` };
   }
 

--- a/module/model-mysql/src/dialect.ts
+++ b/module/model-mysql/src/dialect.ts
@@ -1,4 +1,4 @@
-import { AbstractANSI99Dialect, type JSONSqlPathMode, type TableContext } from '@travetto/model-sql';
+import { AbstractANSI99Dialect, type JSONSqlPathMode, type ResolvedPathContext, type TableContext } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil } from '@travetto/runtime';
 import type { SchemaFieldConfig } from '@travetto/schema';
 
@@ -64,14 +64,26 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     }
   }
 
+  #getArraySqlPath(sqlPath: string, context?: ResolvedPathContext): string {
+    if (!context?.arrayPath || context.arrayPath.length === 0 || !context.subPath || context.subPath.length === 0) {
+      return sqlPath;
+    }
+    const columnName = this.escapeIdentifier(context.arrayPath[0]);
+    const arrayPathPart = context.arrayPath.length > 1 ? context.arrayPath.slice(1).join('.') : '';
+    const jsonPathExpr = arrayPathPart ? `$.${arrayPathPart}[*].${context.subPath.join('.')}` : `$[*].${context.subPath.join('.')}`;
+    return `JSON_EXTRACT(${columnName}, '${jsonPathExpr}')`;
+  }
+
   compileArrayAll(
     sqlPath: string,
     identifier: string,
     value: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    return { sql: `JSON_CONTAINS(${sqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(value) };
+    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+    return { sql: `JSON_CONTAINS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(value) };
   }
 
   compileArrayEquals(
@@ -79,9 +91,12 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     identifier: string,
     values: unknown,
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    return { sql: `JSON_CONTAINS(${sqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(values) };
+    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+    const val = context?.subPath?.length && !Array.isArray(values) ? [values] : values;
+    return { sql: `JSON_CONTAINS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(val) };
   }
 
   compileArrayAny(
@@ -89,13 +104,22 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     identifier: string,
     values: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    return { sql: `JSON_OVERLAPS(${sqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(values) };
+    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+    return { sql: `JSON_OVERLAPS(${targetSqlPath}, ${identifier})`, formatted: JSONUtil.toUTF8(values) };
   }
 
-  compileArrayExists(sqlPath: string, identifier: string, field: SchemaFieldConfig, topLevel?: boolean): { sql: string } {
-    return { sql: `(${sqlPath} IS NOT NULL AND JSON_LENGTH(${sqlPath}) > 0)` };
+  compileArrayExists(
+    sqlPath: string,
+    identifier: string,
+    field: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string } {
+    const targetSqlPath = this.#getArraySqlPath(sqlPath, context);
+    return { sql: `(${targetSqlPath} IS NOT NULL AND JSON_LENGTH(${targetSqlPath}) > 0)` };
   }
 
   compileJsonEquality(sqlPath: string, identifier: string): string {

--- a/module/model-postgres/src/dialect.ts
+++ b/module/model-postgres/src/dialect.ts
@@ -1,4 +1,4 @@
-import { AbstractANSI99Dialect, type TableContext } from '@travetto/model-sql';
+import { AbstractANSI99Dialect, type ResolvedPathContext, type TableContext } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil } from '@travetto/runtime';
 import { type SchemaFieldConfig, SchemaRegistryIndex } from '@travetto/schema';
 
@@ -74,18 +74,46 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     return `$${index}`;
   }
 
+  #buildContainmentPayload(value: unknown, context?: ResolvedPathContext): unknown {
+    if (!context?.subPath || context.subPath.length === 0) {
+      return Array.isArray(value) ? value : [value];
+    }
+    let currentPayload: unknown = value;
+    for (let index = context.subPath.length - 1; index >= 0; index--) {
+      currentPayload = { [context.subPath[index]]: currentPayload };
+    }
+    currentPayload = [currentPayload];
+
+    if (context.arrayPath && context.arrayPath.length > 1) {
+      for (let index = context.arrayPath.length - 1; index >= 1; index--) {
+        currentPayload = { [context.arrayPath[index]]: currentPayload };
+      }
+    }
+    return currentPayload;
+  }
+
+  #getJsonbColumnPath(sqlPath: string, context?: ResolvedPathContext): string {
+    if (context?.subPath && context.subPath.length > 0 && context.arrayPath && context.arrayPath.length > 0) {
+      return this.escapeIdentifier(context.arrayPath[0]);
+    }
+    return sqlPath;
+  }
+
   compileArrayAll(
     sqlPath: string,
     identifier: string,
     value: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    if (topLevel && !SchemaRegistryIndex.has(field.type)) {
+    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
       return { sql: `${sqlPath} @> ${identifier}`, formatted: value };
     }
-    const jsonbPath = topLevel ? sqlPath : `(${sqlPath})::jsonb`;
-    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(value) };
+    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
+    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
+    const payload = this.#buildContainmentPayload(value, context);
+    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(payload) };
   }
 
   compileArrayEquals(
@@ -93,17 +121,19 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     identifier: string,
     values: unknown,
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    if (topLevel && !SchemaRegistryIndex.has(field.type)) {
+    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
       if (Array.isArray(values)) {
         return { sql: `${sqlPath} @> ${identifier}`, formatted: values };
       }
       return { sql: `${identifier} = ANY(${sqlPath})`, formatted: values };
     }
-    const jsonbPath = topLevel ? sqlPath : `(${sqlPath})::jsonb`;
-    const val = Array.isArray(values) ? values : [values];
-    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(val) };
+    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
+    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
+    const payload = this.#buildContainmentPayload(values, context);
+    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(payload) };
   }
 
   compileArrayAny(
@@ -111,22 +141,31 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     identifier: string,
     values: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown } {
-    if (topLevel && !SchemaRegistryIndex.has(field.type)) {
+    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
       return { sql: `${sqlPath} && ${identifier}`, formatted: values };
     }
-    const jsonbPath = topLevel ? sqlPath : `(${sqlPath})::jsonb`;
-    const formatted = values.map(v => JSONUtil.toUTF8(Array.isArray(v) ? v : [v]));
+    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
+    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
+    const formatted = values.map(v => JSONUtil.toUTF8(this.#buildContainmentPayload(v, context)));
     return { sql: `${jsonbPath} @> ANY(${identifier}::jsonb[])`, formatted };
   }
 
-  compileArrayExists(sqlPath: string, identifier: string, field: SchemaFieldConfig, topLevel?: boolean): { sql: string } {
-    if (topLevel && !SchemaRegistryIndex.has(field.type)) {
+  compileArrayExists(
+    sqlPath: string,
+    identifier: string,
+    field: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string } {
+    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
       return { sql: `(${sqlPath} IS NOT NULL AND cardinality(${sqlPath}) > 0)` };
     }
-    const jsonbPath = topLevel ? sqlPath : `(${sqlPath})::jsonb`;
-    return { sql: `(${sqlPath} IS NOT NULL AND ${jsonbPath} <> '[]'::jsonb)` };
+    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
+    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
+    return { sql: `(${jsonbColumn} IS NOT NULL AND ${jsonbPath} <> '[]'::jsonb)` };
   }
 
   getRegexOperator(caseInsensitive: boolean): string {

--- a/module/model-postgres/src/dialect.ts
+++ b/module/model-postgres/src/dialect.ts
@@ -78,94 +78,89 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     if (!context?.subPath || context.subPath.length === 0) {
       return Array.isArray(value) ? value : [value];
     }
-    let currentPayload: unknown = value;
-    for (let index = context.subPath.length - 1; index >= 0; index--) {
-      currentPayload = { [context.subPath[index]]: currentPayload };
+
+    let currentPayload: unknown;
+    if (Array.isArray(value)) {
+      currentPayload = value.map(item => {
+        let itemPayload: unknown = item;
+        for (let index = context.subPath!.length - 1; index >= 0; index--) {
+          itemPayload = { [context.subPath![index]]: itemPayload };
+        }
+        return itemPayload;
+      });
+    } else {
+      currentPayload = value;
+      for (let index = context.subPath.length - 1; index >= 0; index--) {
+        currentPayload = { [context.subPath[index]]: currentPayload };
+      }
+      currentPayload = [currentPayload];
     }
-    currentPayload = [currentPayload];
 
     if (context.arrayPath && context.arrayPath.length > 1) {
       for (let index = context.arrayPath.length - 1; index >= 1; index--) {
         currentPayload = { [context.arrayPath[index]]: currentPayload };
       }
+      return currentPayload;
     }
+
     return currentPayload;
   }
 
-  #getJsonbColumnPath(sqlPath: string, context?: ResolvedPathContext): string {
-    if (context?.subPath && context.subPath.length > 0 && context.arrayPath && context.arrayPath.length > 0) {
-      return this.escapeIdentifier(context.arrayPath[0]);
-    }
-    return sqlPath;
+  #getPostgresArrayTarget(context: ResolvedPathContext): {
+    isNative: boolean;
+    sqlPath: string;
+    jsonbPath: string;
+    buildPayload: (val: unknown) => unknown;
+  } {
+    const arrayField = context.arrayField ?? context.leafField;
+    const isTopLevel = (context.arrayPath?.length ?? 1) === 1;
+    const hasSubPath = (context.subPath?.length ?? 0) > 0;
+    const isScalarArray = arrayField ? !SchemaRegistryIndex.has(arrayField.type) : true;
+    const isNative = isTopLevel && !hasSubPath && isScalarArray;
+
+    const targetPath =
+      hasSubPath && context.arrayPath && context.arrayPath.length > 0 ? this.escapeIdentifier(context.arrayPath[0]) : context.sqlPath;
+
+    const jsonbPath = isTopLevel && !hasSubPath ? targetPath : `(${targetPath})::jsonb`;
+    const buildPayload = (value: unknown): unknown => this.#buildContainmentPayload(value, context);
+
+    return { isNative, sqlPath: context.sqlPath, jsonbPath, buildPayload };
   }
 
-  compileArrayAll(
-    sqlPath: string,
-    identifier: string,
-    value: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
-      return { sql: `${sqlPath} @> ${identifier}`, formatted: value };
+  compileArrayAll(context: ResolvedPathContext, identifier: string, value: unknown[]): { sql: string; formatted: unknown } {
+    const target = this.#getPostgresArrayTarget(context);
+    if (target.isNative) {
+      return { sql: `${target.sqlPath} @> ${identifier}`, formatted: value };
     }
-    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
-    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
-    const payload = this.#buildContainmentPayload(value, context);
-    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(payload) };
+    return { sql: `${target.jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(target.buildPayload(value)) };
   }
 
-  compileArrayEquals(
-    sqlPath: string,
-    identifier: string,
-    values: unknown,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
+  compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown): { sql: string; formatted: unknown } {
+    const target = this.#getPostgresArrayTarget(context);
+    if (target.isNative) {
       if (Array.isArray(values)) {
-        return { sql: `${sqlPath} @> ${identifier}`, formatted: values };
+        return { sql: `${target.sqlPath} @> ${identifier}`, formatted: values };
       }
-      return { sql: `${identifier} = ANY(${sqlPath})`, formatted: values };
+      return { sql: `${identifier} = ANY(${target.sqlPath})`, formatted: values };
     }
-    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
-    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
-    const payload = this.#buildContainmentPayload(values, context);
-    return { sql: `${jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(payload) };
+    return { sql: `${target.jsonbPath} @> ${identifier}::jsonb`, formatted: JSONUtil.toUTF8(target.buildPayload(values)) };
   }
 
-  compileArrayAny(
-    sqlPath: string,
-    identifier: string,
-    values: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
-      return { sql: `${sqlPath} && ${identifier}`, formatted: values };
+  compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]): { sql: string; formatted: unknown } {
+    const target = this.#getPostgresArrayTarget(context);
+    if (target.isNative) {
+      return { sql: `${target.sqlPath} && ${identifier}`, formatted: values };
     }
-    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
-    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
-    const formatted = values.map(v => JSONUtil.toUTF8(this.#buildContainmentPayload(v, context)));
-    return { sql: `${jsonbPath} @> ANY(${identifier}::jsonb[])`, formatted };
+    const formatted = values.map(v => JSONUtil.toUTF8(target.buildPayload(v)));
+    return { sql: `${target.jsonbPath} @> ANY(${identifier}::jsonb[])`, formatted };
   }
 
-  compileArrayExists(
-    sqlPath: string,
-    identifier: string,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string } {
-    if (topLevel && !context?.subPath?.length && !SchemaRegistryIndex.has(field.type)) {
-      return { sql: `(${sqlPath} IS NOT NULL AND cardinality(${sqlPath}) > 0)` };
+  compileArrayExists(context: ResolvedPathContext, identifier?: string): { sql: string } {
+    const target = this.#getPostgresArrayTarget(context);
+    if (target.isNative) {
+      return { sql: `(${target.sqlPath} IS NOT NULL AND cardinality(${target.sqlPath}) > 0)` };
     }
-    const jsonbColumn = this.#getJsonbColumnPath(sqlPath, context);
-    const jsonbPath = topLevel && !context?.subPath?.length ? jsonbColumn : `(${jsonbColumn})::jsonb`;
-    return { sql: `(${jsonbColumn} IS NOT NULL AND ${jsonbPath} <> '[]'::jsonb)` };
+    return { sql: `(${target.jsonbPath} IS NOT NULL AND ${target.jsonbPath} <> '[]'::jsonb)` };
   }
 
   getRegexOperator(caseInsensitive: boolean): string {

--- a/module/model-query-language/src/parser.ts
+++ b/module/model-query-language/src/parser.ts
@@ -145,7 +145,7 @@ export class QueryLanguageParser {
         default:
           top.push(token);
       }
-      token = tokens[++position];
+      token = tokens[(position += 1)];
     }
 
     this.condense(top, 'or');

--- a/module/model-query/src/util/suggest.ts
+++ b/module/model-query/src/util/suggest.ts
@@ -86,7 +86,7 @@ export class ModelQuerySuggestUtil {
 
     for (const result of results) {
       let resultValue = result[castKey<T>(parts[0])];
-      for (let i = 1; i < parts.length; i++) {
+      for (let i = 1; i < parts.length; i += 1) {
         resultValue = resultValue[castKey(parts[i])];
       }
       if (Array.isArray(resultValue)) {

--- a/module/model-query/support/test/model.ts
+++ b/module/model-query/support/test/model.ts
@@ -99,3 +99,19 @@ export class BigIntModel {
   largeNumber: bigint;
   optionalBigInt?: bigint;
 }
+
+@Schema()
+export class Child {
+  name: string;
+}
+
+@Schema()
+export class Family {
+  children?: Child[];
+}
+
+@Model()
+export class PersonFamily implements ModelType {
+  id: string;
+  family?: Family;
+}

--- a/module/model-query/support/test/query.ts
+++ b/module/model-query/support/test/query.ts
@@ -644,5 +644,57 @@ export abstract class ModelQuerySuite extends BaseModelSuite<ModelQuerySupport &
       }
     });
     assert(eqResults.length === 1);
+
+    const neResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: {
+              $ne: 'five'
+            }
+          }
+        }
+      }
+    });
+    assert(neResults.length === 2);
+
+    const ninResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: {
+              $nin: ['one', 'two']
+            }
+          }
+        }
+      }
+    });
+    assert(ninResults.length === 2);
+
+    const allResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: {
+              $all: ['one', 'two']
+            }
+          }
+        }
+      }
+    });
+    assert(allResults.length === 1);
+
+    const existsResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: {
+              $exists: true
+            }
+          }
+        }
+      }
+    });
+    assert(existsResults.length === 3);
   }
 }

--- a/module/model-query/support/test/query.ts
+++ b/module/model-query/support/test/query.ts
@@ -7,7 +7,7 @@ import { Suite, Test } from '@travetto/test';
 import { BaseModelSuite } from '@travetto/model/support/test/base.ts';
 
 import type { ModelQuerySupport } from '../../src/types/query.ts';
-import { Aged, Location, Names, Note, Person, SimpleList, WithNestedLists, WithNestedNestedLists } from './model.ts';
+import { Aged, Location, Names, Note, Person, PersonFamily, SimpleList, WithNestedLists, WithNestedNestedLists } from './model.ts';
 
 @Suite()
 export abstract class ModelQuerySuite extends BaseModelSuite<ModelQuerySupport & ModelCrudSupport> {
@@ -536,5 +536,113 @@ export abstract class ModelQuerySuite extends BaseModelSuite<ModelQuerySupport &
     });
 
     assert(total === 1);
+  }
+
+  @Test('Verify array of objects property queries')
+  async verifyArrayOfObjectsProperty() {
+    const service = await this.service;
+
+    await service.create(
+      Note,
+      Note.from({
+        entities: [
+          { id: '1', label: 'one' },
+          { id: '2', label: 'two' }
+        ]
+      })
+    );
+
+    await service.create(
+      Note,
+      Note.from({
+        entities: [
+          { id: '3', label: 'three' },
+          { id: '4', label: 'four' }
+        ]
+      })
+    );
+
+    await service.create(
+      Note,
+      Note.from({
+        entities: [{ id: '5', label: 'five' }]
+      })
+    );
+
+    const inResults = await service.query(Note, {
+      where: {
+        entities: {
+          label: {
+            $in: ['one', 'four', 'missing']
+          }
+        }
+      }
+    });
+    assert(inResults.length === 2);
+
+    const eqResults = await service.query(Note, {
+      where: {
+        entities: {
+          label: 'five'
+        }
+      }
+    });
+    assert(eqResults.length === 1);
+  }
+
+  @Test('Verify nested object array property queries')
+  async verifyNestedObjectArrayProperty() {
+    const service = await this.service;
+
+    await service.create(
+      PersonFamily,
+      PersonFamily.from({
+        family: {
+          children: [{ name: 'one' }, { name: 'two' }]
+        }
+      })
+    );
+
+    await service.create(
+      PersonFamily,
+      PersonFamily.from({
+        family: {
+          children: [{ name: 'three' }, { name: 'four' }]
+        }
+      })
+    );
+
+    await service.create(
+      PersonFamily,
+      PersonFamily.from({
+        family: {
+          children: [{ name: 'five' }]
+        }
+      })
+    );
+
+    const inResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: {
+              $in: ['one', 'two', 'three']
+            }
+          }
+        }
+      }
+    });
+    assert(inResults.length === 2);
+
+    const eqResults = await service.query(PersonFamily, {
+      where: {
+        family: {
+          children: {
+            name: 'five'
+          }
+        }
+      }
+    });
+    assert(eqResults.length === 1);
   }
 }

--- a/module/model-query/support/test/query.ts
+++ b/module/model-query/support/test/query.ts
@@ -263,8 +263,8 @@ export abstract class ModelQuerySuite extends BaseModelSuite<ModelQuerySupport &
 
     const toAdd = [];
 
-    for (let i = 0; i < 5; i++) {
-      for (let j = 0; j < 5; j++) {
+    for (let i = 0; i < 5; i += 1) {
+      for (let j = 0; j < 5; j += 1) {
         toAdd.push(
           Location.from({
             point: [i, j]

--- a/module/model-s3/test/service.ts
+++ b/module/model-s3/test/service.ts
@@ -45,7 +45,7 @@ class S3BlobSuite extends ModelBlobSuite {
   async largeFile() {
     const service: S3ModelService = castTo(await this.service);
     const buffer = BinaryUtil.binaryArrayToBuffer(BinaryUtil.makeBinaryArray(1.5 * service.config.chunkSize));
-    for (let i = 0; i < buffer.byteLength; i++) {
+    for (let i = 0; i < buffer.byteLength; i += 1) {
       buffer.writeUInt8(Math.trunc(Math.random() * 255), i);
     }
 

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -5,7 +5,7 @@ import { isModelQueryIndex, ModelQueryUtil, type SortClause, type WhereClause } 
 import { type Class, castTo, JSONUtil, RuntimeError } from '@travetto/runtime';
 import { DataUtil, type SchemaFieldConfig, SchemaRegistryIndex } from '@travetto/schema';
 
-import type { JSONSqlPathMode, SchemaContext, TableContext } from './types.ts';
+import type { JSONSqlPathMode, ResolvedPathContext, SchemaContext, TableContext } from './types.ts';
 
 export interface TransactionStatements {
   begin: string;
@@ -69,23 +69,32 @@ export abstract class AbstractANSI99Dialect {
     identifier: string,
     value: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown };
   abstract compileArrayEquals(
     sqlPath: string,
     identifier: string,
     values: unknown,
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown };
   abstract compileArrayAny(
     sqlPath: string,
     identifier: string,
     values: unknown[],
     field: SchemaFieldConfig,
-    topLevel?: boolean
+    topLevel?: boolean,
+    context?: ResolvedPathContext
   ): { sql: string; formatted: unknown };
-  abstract compileArrayExists(sqlPath: string, identifier: string, field: SchemaFieldConfig, topLevel?: boolean): { sql: string };
+  abstract compileArrayExists(
+    sqlPath: string,
+    identifier: string,
+    field: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string };
 
   abstract getRegexOperator(caseInsensitive: boolean): string;
   abstract formatRegex(source: string, caseInsensitive: boolean): string;
@@ -272,11 +281,7 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     return sortClauses.length ? `ORDER BY ${sortClauses.join(', ')}` : '';
   }
 
-  resolvePath<T extends ModelType>(
-    tableContext: TableContext<T>,
-    path: string[],
-    mode: JSONSqlPathMode
-  ): { sqlPath: string; leafField?: SchemaFieldConfig } {
+  resolvePath<T extends ModelType>(tableContext: TableContext<T>, path: string[], mode: JSONSqlPathMode): ResolvedPathContext {
     const firstSegment = path[0];
 
     if (tableContext.simpleFields.has(firstSegment)) {
@@ -293,6 +298,9 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     }
 
     let currentField: SchemaFieldConfig | undefined = tableContext.complexFields.get(firstSegment);
+    let arrayField: SchemaFieldConfig | undefined = currentField?.array ? currentField : undefined;
+    let arrayIndex: number | undefined = currentField?.array ? 0 : undefined;
+
     let currentClass = currentField?.type;
     const jsonPath = path.slice(1);
 
@@ -300,6 +308,10 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       const segment = jsonPath[index];
       const subclassConfiguration = SchemaRegistryIndex.getOptional(currentClass!)?.get();
       currentField = subclassConfiguration?.fields[segment];
+      if (currentField?.array && !arrayField) {
+        arrayField = currentField;
+        arrayIndex = index + 1;
+      }
       currentClass = currentField?.type;
     }
 
@@ -307,6 +319,10 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       const leafSegment = jsonPath[jsonPath.length - 1];
       const subclassConfiguration = SchemaRegistryIndex.getOptional(currentClass!)?.get();
       currentField = subclassConfiguration?.fields[leafSegment];
+      if (currentField?.array && !arrayField) {
+        arrayField = currentField;
+        arrayIndex = path.length - 1;
+      }
     }
 
     let compiledPath = this.compileIndexPath(tableContext, path, mode);
@@ -315,7 +331,16 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       compiledPath = this.castColumn(compiledPath, currentField.type);
     }
 
-    return { sqlPath: compiledPath, leafField: currentField };
+    const arrayPath = arrayIndex !== undefined ? path.slice(0, arrayIndex + 1) : undefined;
+    const subPath = arrayIndex !== undefined ? path.slice(arrayIndex + 1) : undefined;
+
+    return {
+      sqlPath: compiledPath,
+      leafField: currentField,
+      arrayField,
+      arrayPath,
+      subPath
+    };
   }
 
   #compileClause<T extends ModelType>(
@@ -389,14 +414,11 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       const isPlainObject = DataUtil.isPlainObject(value);
       const firstKey = isPlainObject ? Object.keys(value)[0] : '';
 
-      const { leafField } = this.resolvePath(tableContext, currentPath, 'read');
       const nextIdentificationPath = `${identificationPath}__${index}`;
 
       if (isPlainObject) {
         if (firstKey.startsWith('$')) {
           clauses.push(this.#compileOperator(tableContext, currentPath, value as Record<string, unknown>, nextIdentificationPath));
-        } else if (leafField?.array) {
-          clauses.push(this.#compileOperator(tableContext, currentPath, { $eq: value }, nextIdentificationPath));
         } else {
           clauses.push(this.#compileSimple(tableContext, value as Record<string, unknown>, currentPath, nextIdentificationPath));
         }
@@ -414,7 +436,9 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     operation: Record<string, unknown>,
     identificationPath: IdentificationPath = ''
   ): QueryClause {
-    const { sqlPath, leafField } = this.resolvePath(tableContext, path, 'read');
+    const resolvedContext = this.resolvePath(tableContext, path, 'read');
+    const { sqlPath, leafField, arrayField } = resolvedContext;
+    const effectiveArrayField = leafField?.array ? leafField : arrayField;
     const clauses: QueryClause[] = [];
 
     let index = 0;
@@ -432,16 +456,17 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
 
       let clause: QueryClause;
 
-      if (leafField?.array) {
+      if (effectiveArrayField) {
+        const topLevel = (resolvedContext.arrayPath?.length ?? path.length) === 1;
         if (operator === '$eq' || operator === '$ne') {
-          const { sql, formatted } = this.compileArrayEquals(sqlPath, identifier, value, leafField, path.length === 1);
+          const { sql, formatted } = this.compileArrayEquals(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
           const finalSql = operator === '$ne' ? `NOT(${sql})` : sql;
           clause = { parameters: { [identifier]: formatted }, sql: finalSql };
         } else if (operator === '$in' || operator === '$nin') {
           if (!Array.isArray(value) || value.length === 0) {
             clause = operator === '$in' ? { sql: '1=0' } : {};
           } else {
-            const { sql, formatted } = this.compileArrayAny(sqlPath, identifier, value, leafField, path.length === 1);
+            const { sql, formatted } = this.compileArrayAny(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
             const finalSql = operator === '$nin' ? `NOT(${sql})` : sql;
             clause = { sql: finalSql, parameters: { [identifier]: formatted } };
           }
@@ -449,11 +474,11 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
           if (!Array.isArray(value) || value.length === 0) {
             clause = { sql: '1=0' };
           } else {
-            const { sql, formatted } = this.compileArrayAll(sqlPath, identifier, value, leafField, path.length === 1);
+            const { sql, formatted } = this.compileArrayAll(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
             clause = { sql, parameters: { [identifier]: formatted } };
           }
         } else if (operator === '$exists') {
-          const { sql } = this.compileArrayExists(sqlPath, identifier, leafField, path.length === 1);
+          const { sql } = this.compileArrayExists(sqlPath, identifier, effectiveArrayField, topLevel, resolvedContext);
           const finalSql = !value ? `NOT(${sql})` : sql;
           clause = { sql: finalSql };
         } else {

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -76,12 +76,17 @@ export abstract class AbstractANSI99Dialect {
   compileJsonEquality?(sqlPath: string, identifier: string): string;
   shiftPlaceholders?(whereSQL: string, offset: number): string;
 
-  compileIndexPath(context: TableContext, path: string[], mode: JSONSqlPathMode): string {
+  buildSqlPath<T extends ModelType>(tableContext: TableContext<T>, path: string[], mode: JSONSqlPathMode): string {
     const firstSegment = path[0];
     const escapedFirst = this.escapeIdentifier(firstSegment);
-    if (context.simpleFields.has(firstSegment)) {
+    if (tableContext.simpleFields.has(firstSegment)) {
       if (path.length > 1) {
-        throw new RuntimeError(`Cannot create nested index under column "${firstSegment}" in table "${context.tableName}"`);
+        throw new RuntimeError(
+          `Cannot traverse nested properties under simple column "${firstSegment}" in table "${tableContext.tableName}"`,
+          {
+            category: 'data'
+          }
+        );
       }
       return escapedFirst;
     } else {
@@ -91,6 +96,10 @@ export abstract class AbstractANSI99Dialect {
       }
       return this.compileJsonIndexPath(escapedFirst, nestedSegments, mode);
     }
+  }
+
+  compileIndexPath(context: TableContext, path: string[], mode: JSONSqlPathMode): string {
+    return this.buildSqlPath(context, path, mode);
   }
 
   getCreateIndexSQL(context: TableContext, indexConfig: IndexConfig): string {
@@ -254,7 +263,14 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     return sortClauses.length ? `ORDER BY ${sortClauses.join(', ')}` : '';
   }
 
-  resolvePath<T extends ModelType>(tableContext: TableContext<T>, path: string[], mode: JSONSqlPathMode): ResolvedPathContext {
+  #resolveSchemaPath<T extends ModelType>(
+    tableContext: TableContext<T>,
+    path: string[]
+  ): {
+    leafField?: SchemaFieldConfig;
+    arrayField?: SchemaFieldConfig;
+    arraySegmentIndex?: number;
+  } {
     const firstSegment = path[0];
 
     if (tableContext.simpleFields.has(firstSegment)) {
@@ -266,13 +282,12 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
           }
         );
       }
-      const leafField = tableContext.simpleFields.get(firstSegment);
-      return { sqlPath: this.escapeIdentifier(firstSegment), leafField };
+      return { leafField: tableContext.simpleFields.get(firstSegment) };
     }
 
     let currentField: SchemaFieldConfig | undefined = tableContext.complexFields.get(firstSegment);
     let arrayField: SchemaFieldConfig | undefined = currentField?.array ? currentField : undefined;
-    let arrayIndex: number | undefined = currentField?.array ? 0 : undefined;
+    let arraySegmentIndex: number | undefined = currentField?.array ? 0 : undefined;
     let currentClass = currentField?.type;
 
     for (let pathIndex = 1; pathIndex < path.length; pathIndex++) {
@@ -281,23 +296,37 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       currentField = subclassConfiguration?.fields[segment];
       if (currentField?.array && !arrayField) {
         arrayField = currentField;
-        arrayIndex = pathIndex;
+        arraySegmentIndex = pathIndex;
       }
       currentClass = currentField?.type;
     }
 
-    let compiledPath = this.compileIndexPath(tableContext, path, mode);
+    return {
+      leafField: currentField,
+      arrayField,
+      arraySegmentIndex
+    };
+  }
 
-    if (currentField && !currentField.array) {
-      compiledPath = this.castColumn(compiledPath, currentField.type);
+  resolvePath<T extends ModelType>(tableContext: TableContext<T>, path: string[], mode: JSONSqlPathMode): ResolvedPathContext {
+    const firstSegment = path[0];
+
+    if (tableContext.simpleFields.has(firstSegment)) {
+      const { leafField } = this.#resolveSchemaPath(tableContext, path);
+      return { sqlPath: this.buildSqlPath(tableContext, path, mode), leafField };
     }
 
-    const arrayPath = arrayIndex !== undefined ? path.slice(0, arrayIndex + 1) : undefined;
-    const subPath = arrayIndex !== undefined ? path.slice(arrayIndex + 1) : undefined;
+    const { leafField, arrayField, arraySegmentIndex } = this.#resolveSchemaPath(tableContext, path);
+    const sqlPath = this.buildSqlPath(tableContext, path, mode);
+
+    const finalSqlPath = leafField && !leafField.array ? this.castColumn(sqlPath, leafField.type) : sqlPath;
+
+    const arrayPath = arraySegmentIndex !== undefined ? path.slice(0, arraySegmentIndex + 1) : undefined;
+    const subPath = arraySegmentIndex !== undefined ? path.slice(arraySegmentIndex + 1) : undefined;
 
     return {
-      sqlPath: compiledPath,
-      leafField: currentField,
+      sqlPath: finalSqlPath,
+      leafField,
       arrayField,
       arrayPath,
       subPath

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -64,37 +64,10 @@ export abstract class AbstractANSI99Dialect {
 
   abstract getColumnType(fieldConfiguration: SchemaFieldConfig): string;
   abstract compileJsonIndexPath(columnName: string, jsonPath: string[], mode: JSONSqlPathMode): string;
-  abstract compileArrayAll(
-    sqlPath: string,
-    identifier: string,
-    value: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown };
-  abstract compileArrayEquals(
-    sqlPath: string,
-    identifier: string,
-    values: unknown,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown };
-  abstract compileArrayAny(
-    sqlPath: string,
-    identifier: string,
-    values: unknown[],
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown };
-  abstract compileArrayExists(
-    sqlPath: string,
-    identifier: string,
-    field: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string };
+  abstract compileArrayAll(context: ResolvedPathContext, identifier: string, value: unknown[]): { sql: string; formatted: unknown };
+  abstract compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown): { sql: string; formatted: unknown };
+  abstract compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]): { sql: string; formatted: unknown };
+  abstract compileArrayExists(context: ResolvedPathContext, identifier?: string): { sql: string };
 
   abstract getRegexOperator(caseInsensitive: boolean): string;
   abstract formatRegex(source: string, caseInsensitive: boolean): string;
@@ -300,29 +273,17 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     let currentField: SchemaFieldConfig | undefined = tableContext.complexFields.get(firstSegment);
     let arrayField: SchemaFieldConfig | undefined = currentField?.array ? currentField : undefined;
     let arrayIndex: number | undefined = currentField?.array ? 0 : undefined;
-
     let currentClass = currentField?.type;
-    const jsonPath = path.slice(1);
 
-    for (let index = 0; index < jsonPath.length - 1; index++) {
-      const segment = jsonPath[index];
+    for (let pathIndex = 1; pathIndex < path.length; pathIndex++) {
+      const segment = path[pathIndex];
       const subclassConfiguration = SchemaRegistryIndex.getOptional(currentClass!)?.get();
       currentField = subclassConfiguration?.fields[segment];
       if (currentField?.array && !arrayField) {
         arrayField = currentField;
-        arrayIndex = index + 1;
+        arrayIndex = pathIndex;
       }
       currentClass = currentField?.type;
-    }
-
-    if (jsonPath.length > 0) {
-      const leafSegment = jsonPath[jsonPath.length - 1];
-      const subclassConfiguration = SchemaRegistryIndex.getOptional(currentClass!)?.get();
-      currentField = subclassConfiguration?.fields[leafSegment];
-      if (currentField?.array && !arrayField) {
-        arrayField = currentField;
-        arrayIndex = path.length - 1;
-      }
     }
 
     let compiledPath = this.compileIndexPath(tableContext, path, mode);
@@ -372,28 +333,6 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     } else {
       return this.#compileSimple(tableContext, clause, [], identificationPath);
     }
-  }
-
-  #buildJsonTemplate(queryObject: Record<string, unknown>): Record<string, unknown> {
-    const template: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(queryObject)) {
-      if (DataUtil.isPlainObject(value)) {
-        const firstKey = Object.keys(value)[0];
-        const valueObject = castTo<Record<string, unknown>>(value);
-        if (firstKey === '$eq') {
-          template[key] = valueObject.$eq;
-        } else if (valueObject.$eq !== undefined) {
-          template[key] = valueObject.$eq;
-        } else if (!firstKey.startsWith('$')) {
-          template[key] = this.#buildJsonTemplate(valueObject);
-        } else {
-          throw new RuntimeError(`Unsupported operator ${firstKey} in nested array query`, { category: 'data' });
-        }
-      } else {
-        template[key] = value;
-      }
-    }
-    return template;
   }
 
   #compileSimple<T extends ModelType>(
@@ -457,16 +396,15 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       let clause: QueryClause;
 
       if (effectiveArrayField) {
-        const topLevel = (resolvedContext.arrayPath?.length ?? path.length) === 1;
         if (operator === '$eq' || operator === '$ne') {
-          const { sql, formatted } = this.compileArrayEquals(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
+          const { sql, formatted } = this.compileArrayEquals(resolvedContext, identifier, value);
           const finalSql = operator === '$ne' ? `NOT(${sql})` : sql;
           clause = { parameters: { [identifier]: formatted }, sql: finalSql };
         } else if (operator === '$in' || operator === '$nin') {
           if (!Array.isArray(value) || value.length === 0) {
             clause = operator === '$in' ? { sql: '1=0' } : {};
           } else {
-            const { sql, formatted } = this.compileArrayAny(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
+            const { sql, formatted } = this.compileArrayAny(resolvedContext, identifier, value);
             const finalSql = operator === '$nin' ? `NOT(${sql})` : sql;
             clause = { sql: finalSql, parameters: { [identifier]: formatted } };
           }
@@ -474,11 +412,11 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
           if (!Array.isArray(value) || value.length === 0) {
             clause = { sql: '1=0' };
           } else {
-            const { sql, formatted } = this.compileArrayAll(sqlPath, identifier, value, effectiveArrayField, topLevel, resolvedContext);
+            const { sql, formatted } = this.compileArrayAll(resolvedContext, identifier, value);
             clause = { sql, parameters: { [identifier]: formatted } };
           }
         } else if (operator === '$exists') {
-          const { sql } = this.compileArrayExists(sqlPath, identifier, effectiveArrayField, topLevel, resolvedContext);
+          const { sql } = this.compileArrayExists(resolvedContext, identifier);
           const finalSql = !value ? `NOT(${sql})` : sql;
           clause = { sql: finalSql };
         } else {

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -290,7 +290,7 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     let arraySegmentIndex: number | undefined = currentField?.array ? 0 : undefined;
     let currentClass = currentField?.type;
 
-    for (let pathIndex = 1; pathIndex < path.length; pathIndex++) {
+    for (let pathIndex = 1; pathIndex < path.length; pathIndex += 1) {
       const segment = path[pathIndex];
       const subclassConfiguration = SchemaRegistryIndex.getOptional(currentClass!)?.get();
       currentField = subclassConfiguration?.fields[segment];

--- a/module/model-sql/src/service.ts
+++ b/module/model-sql/src/service.ts
@@ -495,7 +495,7 @@ export abstract class BaseSQLModelService<C = unknown>
         try {
           const result = await this.connection.execute(command.sql, command.values);
           if (command.type === 'update' && result.count === 0) {
-            counts.error++;
+            counts.error += 1;
             errors.push(new NotFoundError(modelClass, command.identifier!));
           } else if (command.type === 'delete' && result.count < command.count) {
             counts.delete += result.count;

--- a/module/model-sql/src/types.ts
+++ b/module/model-sql/src/types.ts
@@ -15,3 +15,11 @@ export interface TableContext<T extends ModelType = ModelType> extends SchemaCon
   tableName: string;
   database?: string;
 }
+
+export interface ResolvedPathContext {
+  sqlPath: string;
+  leafField?: SchemaFieldConfig;
+  arrayField?: SchemaFieldConfig;
+  arrayPath?: string[];
+  subPath?: string[];
+}

--- a/module/model-sql/support/test/query.ts
+++ b/module/model-sql/support/test/query.ts
@@ -8,7 +8,7 @@ import { BeforeAll, Suite, Test } from '@travetto/test';
 
 import { AbstractANSI99Dialect } from '../../src/dialect.ts';
 import { SQLModelSchemaUtil } from '../../src/schema.ts';
-import type { TableContext } from '../../src/types.ts';
+import type { ResolvedPathContext, TableContext } from '../../src/types.ts';
 
 @Model()
 class User {
@@ -50,20 +50,20 @@ class MockDialect extends AbstractANSI99Dialect {
     return `$$${index}`;
   }
 
-  compileArrayAll(sqlPath: string, identifier: string, value: unknown[]) {
-    return { sql: `${sqlPath} ALL ${identifier}`, formatted: value };
+  compileArrayAll(context: ResolvedPathContext, identifier: string, value: unknown[]) {
+    return { sql: `${context.sqlPath} ALL ${identifier}`, formatted: value };
   }
 
-  compileArrayEquals(sqlPath: string, identifier: string, values: unknown) {
-    return { sql: `${sqlPath} EQUALS ${identifier}`, formatted: values };
+  compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown) {
+    return { sql: `${context.sqlPath} EQUALS ${identifier}`, formatted: values };
   }
 
-  compileArrayAny(sqlPath: string, identifier: string, values: unknown[]) {
-    return { sql: `${sqlPath} ANY ${identifier}`, formatted: values };
+  compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]) {
+    return { sql: `${context.sqlPath} ANY ${identifier}`, formatted: values };
   }
 
-  compileArrayExists(sqlPath: string, identifier: string) {
-    return { sql: `${sqlPath} IS NOT NULL`, formatted: undefined };
+  compileArrayExists(context: ResolvedPathContext, identifier?: string) {
+    return { sql: `${context.sqlPath} IS NOT NULL`, formatted: undefined };
   }
 
   getRegexOperator(caseInsensitive: boolean) {

--- a/module/model-sqlite/src/dialect.ts
+++ b/module/model-sqlite/src/dialect.ts
@@ -41,9 +41,9 @@ export class SqliteDialect extends AbstractANSI99Dialect {
     return `json_extract(${columnName}, '$.${jsonPath.join('.')}')`;
   }
 
-  #getSqliteArrayContext(sqlPath: string, context?: ResolvedPathContext): { jsonArrayExpr: string; valueExpr: string } {
-    if (!context?.arrayPath || context.arrayPath.length === 0) {
-      return { jsonArrayExpr: sqlPath, valueExpr: 'elem.value' };
+  #getSqliteArrayContext(context: ResolvedPathContext): { jsonArrayExpr: string; valueExpr: string } {
+    if (!context.arrayPath || context.arrayPath.length === 0) {
+      return { jsonArrayExpr: context.sqlPath, valueExpr: 'elem.value' };
     }
 
     const columnName = this.escapeIdentifier(context.arrayPath[0]);
@@ -56,30 +56,16 @@ export class SqliteDialect extends AbstractANSI99Dialect {
     return { jsonArrayExpr, valueExpr };
   }
 
-  compileArrayAll(
-    sqlPath: string,
-    identifier: string,
-    value: unknown[],
-    field?: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
+  compileArrayAll(context: ResolvedPathContext, identifier: string, value: unknown[]): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(context);
     return {
       sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT ${valueExpr} FROM json_each(${jsonArrayExpr}) AS elem))`,
       formatted: JSONUtil.toUTF8(value)
     };
   }
 
-  compileArrayEquals(
-    sqlPath: string,
-    identifier: string,
-    values: unknown,
-    field?: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
+  compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(context);
     if (Array.isArray(values)) {
       return {
         sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT ${valueExpr} FROM json_each(${jsonArrayExpr}) AS elem))`,
@@ -98,29 +84,16 @@ export class SqliteDialect extends AbstractANSI99Dialect {
     };
   }
 
-  compileArrayAny(
-    sqlPath: string,
-    identifier: string,
-    values: unknown[],
-    field?: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string; formatted: unknown } {
-    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
+  compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(context);
     return {
       sql: `EXISTS (SELECT 1 FROM json_each(${jsonArrayExpr}) AS elem WHERE ${valueExpr} IN (SELECT value FROM json_each(${identifier})))`,
       formatted: JSONUtil.toUTF8(values)
     };
   }
 
-  compileArrayExists(
-    sqlPath: string,
-    identifier?: string,
-    field?: SchemaFieldConfig,
-    topLevel?: boolean,
-    context?: ResolvedPathContext
-  ): { sql: string } {
-    const { jsonArrayExpr } = this.#getSqliteArrayContext(sqlPath, context);
+  compileArrayExists(context: ResolvedPathContext, identifier?: string): { sql: string } {
+    const { jsonArrayExpr } = this.#getSqliteArrayContext(context);
     return { sql: `(${jsonArrayExpr} IS NOT NULL AND json_array_length(${jsonArrayExpr}) > 0)` };
   }
 

--- a/module/model-sqlite/src/dialect.ts
+++ b/module/model-sqlite/src/dialect.ts
@@ -1,4 +1,4 @@
-import { AbstractANSI99Dialect, type TableContext, type TransactionStatements } from '@travetto/model-sql';
+import { AbstractANSI99Dialect, type ResolvedPathContext, type TableContext, type TransactionStatements } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil } from '@travetto/runtime';
 import type { SchemaFieldConfig } from '@travetto/schema';
 
@@ -41,41 +41,87 @@ export class SqliteDialect extends AbstractANSI99Dialect {
     return `json_extract(${columnName}, '$.${jsonPath.join('.')}')`;
   }
 
-  compileArrayAll(sqlPath: string, identifier: string, value: unknown[]): { sql: string; formatted: unknown } {
+  #getSqliteArrayContext(sqlPath: string, context?: ResolvedPathContext): { jsonArrayExpr: string; valueExpr: string } {
+    if (!context?.arrayPath || context.arrayPath.length === 0) {
+      return { jsonArrayExpr: sqlPath, valueExpr: 'elem.value' };
+    }
+
+    const columnName = this.escapeIdentifier(context.arrayPath[0]);
+    const jsonArrayExpr =
+      context.arrayPath.length > 1 ? `json_extract(${columnName}, '$.${context.arrayPath.slice(1).join('.')}')` : columnName;
+
+    const valueExpr =
+      context.subPath && context.subPath.length > 0 ? `json_extract(elem.value, '$.${context.subPath.join('.')}')` : 'elem.value';
+
+    return { jsonArrayExpr, valueExpr };
+  }
+
+  compileArrayAll(
+    sqlPath: string,
+    identifier: string,
+    value: unknown[],
+    field?: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
     return {
-      sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT value FROM json_each(${sqlPath})))`,
+      sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT ${valueExpr} FROM json_each(${jsonArrayExpr}) AS elem))`,
       formatted: JSONUtil.toUTF8(value)
     };
   }
 
-  compileArrayEquals(sqlPath: string, identifier: string, values: unknown): { sql: string; formatted: unknown } {
+  compileArrayEquals(
+    sqlPath: string,
+    identifier: string,
+    values: unknown,
+    field?: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
     if (Array.isArray(values)) {
       return {
-        sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT value FROM json_each(${sqlPath})))`,
+        sql: `NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE req.value NOT IN (SELECT ${valueExpr} FROM json_each(${jsonArrayExpr}) AS elem))`,
         formatted: JSONUtil.toUTF8(values)
       };
     }
     if (typeof values === 'object' && values !== null) {
       return {
-        sql: `EXISTS (SELECT 1 FROM json_each(${sqlPath}) AS elem WHERE NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE json_extract(elem.value, '$.' || req.key) IS NOT req.value))`,
+        sql: `EXISTS (SELECT 1 FROM json_each(${jsonArrayExpr}) AS elem WHERE NOT EXISTS (SELECT 1 FROM json_each(${identifier}) AS req WHERE json_extract(elem.value, '$.' || req.key) IS NOT req.value))`,
         formatted: JSONUtil.toUTF8(values)
       };
     }
     return {
-      sql: `EXISTS (SELECT 1 FROM json_each(${sqlPath}) WHERE json_each.value = ${identifier})`,
+      sql: `EXISTS (SELECT 1 FROM json_each(${jsonArrayExpr}) AS elem WHERE ${valueExpr} = ${identifier})`,
       formatted: values
     };
   }
 
-  compileArrayAny(sqlPath: string, identifier: string, values: unknown[]): { sql: string; formatted: unknown } {
+  compileArrayAny(
+    sqlPath: string,
+    identifier: string,
+    values: unknown[],
+    field?: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string; formatted: unknown } {
+    const { jsonArrayExpr, valueExpr } = this.#getSqliteArrayContext(sqlPath, context);
     return {
-      sql: `EXISTS (SELECT 1 FROM json_each(${sqlPath}) AS elem WHERE elem.value IN (SELECT value FROM json_each(${identifier})))`,
+      sql: `EXISTS (SELECT 1 FROM json_each(${jsonArrayExpr}) AS elem WHERE ${valueExpr} IN (SELECT value FROM json_each(${identifier})))`,
       formatted: JSONUtil.toUTF8(values)
     };
   }
 
-  compileArrayExists(sqlPath: string): { sql: string } {
-    return { sql: `(${sqlPath} IS NOT NULL AND json_array_length(${sqlPath}) > 0)` };
+  compileArrayExists(
+    sqlPath: string,
+    identifier?: string,
+    field?: SchemaFieldConfig,
+    topLevel?: boolean,
+    context?: ResolvedPathContext
+  ): { sql: string } {
+    const { jsonArrayExpr } = this.#getSqliteArrayContext(sqlPath, context);
+    return { sql: `(${jsonArrayExpr} IS NOT NULL AND json_array_length(${jsonArrayExpr}) > 0)` };
   }
 
   getRegexOperator(caseInsensitive: boolean): string {

--- a/module/model/support/test/blob.ts
+++ b/module/model/support/test/blob.ts
@@ -155,7 +155,7 @@ export abstract class ModelBlobSuite extends BaseModelSuite<ModelBlobSupport> {
     const service = await this.service;
 
     const bytes = BinaryUtil.binaryArrayToBuffer(BinaryUtil.makeBinaryArray(1.5 * 10000));
-    for (let i = 0; i < bytes.byteLength; i++) {
+    for (let i = 0; i < bytes.byteLength; i += 1) {
       bytes.writeUInt8(Math.trunc(Math.random() * 255), i);
     }
 

--- a/module/repo/support/bin/exec.ts
+++ b/module/repo/support/bin/exec.ts
@@ -157,7 +157,7 @@ export class RepoExecUtil {
           [...active].sort().forEach((text, idx) => {
             activeItems.add({ idx, text });
           });
-          for (let j = active.size; j < workerCount; j++) {
+          for (let j = active.size; j < workerCount; j += 1) {
             activeItems.add({ idx: j, text: '' }); // Force update to remove item if needed
           }
 

--- a/module/runtime/test/queue.ts
+++ b/module/runtime/test/queue.ts
@@ -11,7 +11,7 @@ export class WorkSetTest {
     const comp = items.slice(0);
     const itr = new AsyncQueue();
 
-    for (let i = 0; i < items.length; i++) {
+    for (let i = 0; i < items.length; i += 1) {
       setTimeout(() => itr.add(items[i]), (i + 1) * 1000);
     }
     while (comp.length) {

--- a/module/runtime/test/util.ts
+++ b/module/runtime/test/util.ts
@@ -118,7 +118,7 @@ export class UtilTest {
       'admin,user',
       (rule: string) => rule,
       (rule: string, input: string) => {
-        compareCallCount++;
+        compareCallCount += 1;
         return rule === input;
       },
       (input: string) => input // Cache key function

--- a/module/schema-faker/src/faker.ts
+++ b/module/schema-faker/src/faker.ts
@@ -66,7 +66,7 @@ export class SchemaFaker {
     const max = config.maxlength ? config.maxlength.limit : 10;
     const size = faker.number.int({ min, max });
     const out: unknown[] = [];
-    for (let i = 0; i < size; i++) {
+    for (let i = 0; i < size; i += 1) {
       out.push(this.#value(config, true));
     }
     return out;

--- a/module/schema/src/bind-util.ts
+++ b/module/schema/src/bind-util.ts
@@ -130,7 +130,7 @@ export class BindUtil {
       if (DataUtil.isPlainObject(value)) {
         Object.assign(out, this.flattenPaths(value, `${pre}.`));
       } else if (Array.isArray(value)) {
-        for (let i = 0; i < value.length; i++) {
+        for (let i = 0; i < value.length; i += 1) {
           const element = value[i];
           if (DataUtil.isPlainObject(element)) {
             Object.assign(out, this.flattenPaths(element, `${pre}[${i}].`));

--- a/module/schema/src/data.ts
+++ b/module/schema/src/data.ts
@@ -83,7 +83,7 @@ export class DataUtil {
         } else {
           const valueArray: unknown[] = castTo(value);
           const bArray = b;
-          for (let i = 0; i < bArray.length; i++) {
+          for (let i = 0; i < bArray.length; i += 1) {
             valueArray[i] = this.#deepAssignRaw(valueArray[i], bArray[i], mode);
           }
         }

--- a/module/schema/src/validate/validator.ts
+++ b/module/schema/src/validate/validator.ts
@@ -94,12 +94,12 @@ export class SchemaValidator {
       }
       let errors: ValidationError[] = [];
       if (complex) {
-        for (let i = 0; i < value.length; i++) {
+        for (let i = 0; i < value.length; i += 1) {
           const subErrors = this.#validateFields(resolveFieldMap(type, value[i]), value[i], `${path}[${i}]`);
           errors = errors.concat(subErrors);
         }
       } else {
-        for (let i = 0; i < value.length; i++) {
+        for (let i = 0; i < value.length; i += 1) {
           const subErrors = this.#validateInput(input, value[i]);
           errors.push(...this.#prepareErrors(`${path}[${i}]`, subErrors));
         }

--- a/module/terminal/src/terminal.ts
+++ b/module/terminal/src/terminal.ts
@@ -28,7 +28,7 @@ export class Terminal {
     while (!done) {
       await this.#writer
         .setPosition(position)
-        .write(STD_WAIT_STATES[i++ % STD_WAIT_STATES.length])
+        .write(STD_WAIT_STATES[(i += 1 % STD_WAIT_STATES.length)])
         .commit(true);
       await Util.blockingTimeout(100);
     }

--- a/module/test/src/consumer/types/tap.ts
+++ b/module/test/src/consumer/types/tap.ts
@@ -85,7 +85,7 @@ export class TapEmitter implements TestConsumerShape {
           const text = asrt.message ? `${asrt.text} (${this.#enhancer.failure(asrt.message)})` : asrt.text;
           const location = asrt.import ? `./${path.relative(process.cwd(), assertSourceFile)}` : '<unknown>';
           let subMessage = [
-            this.#enhancer.assertNumber(++subCount),
+            this.#enhancer.assertNumber((subCount += 1)),
             '-',
             this.#enhancer.assertDescription(text),
             StyleUtil.link(
@@ -109,7 +109,7 @@ export class TapEmitter implements TestConsumerShape {
       }
 
       // Track test result
-      let status = `${this.#enhancer.testNumber(++this.#count)} `;
+      let status = `${this.#enhancer.testNumber((this.#count += 1))} `;
       switch (test.status) {
         case 'passed':
           `${this.#enhancer.success('ok')} ${status}`;

--- a/module/transformer/src/util/system.ts
+++ b/module/transformer/src/util/system.ts
@@ -5,7 +5,7 @@ export class SystemUtil {
   static naiveHash(text: string): number {
     let hash = 5381;
 
-    for (let i = 0; i < text.length; i++) {
+    for (let i = 0; i < text.length; i += 1) {
       hash = (hash * 33) ^ text.charCodeAt(i);
     }
 

--- a/module/web/src/util/keygrip.ts
+++ b/module/web/src/util/keygrip.ts
@@ -47,7 +47,7 @@ export class KeyGrip {
     const key = await KeyGrip.getRandomHmacKey();
     const digestBytes = BinaryUtil.binaryArrayToUint8Array(await KeyGrip.hmac(digest, key));
 
-    for (let i = 0; i < this.#keys.length; i++) {
+    for (let i = 0; i < this.#keys.length; i += 1) {
       const signedBytes = BinaryUtil.binaryArrayToUint8Array(await KeyGrip.hmac(await this.sign(data, this.#keys[i]), key));
 
       if (signedBytes.byteLength === digestBytes.byteLength && timingSafeEqual(digestBytes, signedBytes)) {

--- a/module/worker/test/pool.ts
+++ b/module/worker/test/pool.ts
@@ -21,7 +21,7 @@ export class WorkPoolTest {
         total: 5,
         onComplete: ({ output, input, success, progress }) => {
           completedInputs.push(input);
-          completeCount++;
+          completeCount += 1;
           assert.equal(output, input * 2);
           assert.equal(success, true);
           assert.equal(progress.completed, completeCount);
@@ -46,7 +46,7 @@ export class WorkPoolTest {
       isSuccess: output => output % 2 !== 0,
       onComplete: ({ output, success, progress }) => {
         if (!success) {
-          failedCount++;
+          failedCount += 1;
         }
         assert.equal(success, output % 2 !== 0);
         assert.equal(progress.failed, failedCount);

--- a/related/vscode-plugin/src/feature/cli/run/util.ts
+++ b/related/vscode-plugin/src/feature/cli/run/util.ts
@@ -67,7 +67,7 @@ export class CliRunUtil {
     const all = choice.args;
     const selected: string[] = [];
 
-    for (let i = 0; i < all.length; i++) {
+    for (let i = 0; i < all.length; i += 1) {
       const param = all[i]!;
       const result = await ParameterSelector.getParameter({
         param,


### PR DESCRIPTION
## Summary
- Resolves issue where nested array element property queries (e.g. `family.children.name IN ('one', 'two', 'three')`) erroneously performed whole-object equality checks on SQL databases.
- Updated `resolvePath` in `@travetto/model-sql` to return `ResolvedPathContext` with array field and sub-path details.
- Updated `#compileSimple` in `@travetto/model-sql` to recurse down nested property paths when query keys are field names.
- Updated `PostgresDialect` to construct nested JSONB containment queries (`@>`, `@> ANY(...)`).
- Updated `MysqlDialect` to construct wildcard JSON extraction paths (`JSON_EXTRACT(..., '$.children[*].name')`) with `JSON_OVERLAPS` and `JSON_CONTAINS`.
- Updated `SqliteDialect` to extract array element sub-properties via `json_each` and `json_extract`.
- Added test coverage in `@travetto/model-query` test suite covering both direct and nested array of object property queries. All test suites verified passing.