### PR TITLE
feat(model-query): Support regex matching on array fields across dialects

### DIFF
--- a/module/model-elasticsearch/src/internal/query.ts
+++ b/module/model-elasticsearch/src/internal/query.ts
@@ -193,16 +193,21 @@ export class ElasticsearchQueryUtil {
                 } else {
                   items.push({ regexp: { [subPath]: pattern.source.substring(1) } });
                 }
-              } else if (pattern.source.startsWith('\\b') && pattern.source.endsWith('.*') && declaredSchema.specifiers?.includes('text')) {
-                const textField = !pattern.flags.includes('i') && config && config.caseSensitive ? `${subPath}.text_cs` : `${subPath}.text`;
-                const query = pattern.source.substring(2, pattern.source.length - 2);
-                items.push({
-                  match_phrase_prefix: {
-                    [textField]: query
-                  }
-                });
+              } else if (pattern.source.startsWith('\\b') && pattern.source.endsWith('.*')) {
+                const queryText = pattern.source.substring(2, pattern.source.length - 2);
+                if (declaredSchema.specifiers?.includes('text')) {
+                  const textField =
+                    !pattern.flags.includes('i') && config && config.caseSensitive ? `${subPath}.text_cs` : `${subPath}.text`;
+                  items.push({
+                    match_phrase_prefix: {
+                      [textField]: queryText
+                    }
+                  });
+                } else {
+                  items.push({ prefix: { [subPath]: queryText } });
+                }
               } else {
-                items.push({ regexp: { [subPath]: pattern.source } });
+                items.push({ regexp: { [subPath]: pattern.source.replaceAll('\\b', '') } });
               }
               break;
             }

--- a/module/model-mysql/src/dialect.ts
+++ b/module/model-mysql/src/dialect.ts
@@ -118,6 +118,19 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     return { sql: `(${targetSqlPath} IS NOT NULL AND JSON_LENGTH(${targetSqlPath}) > 0)` };
   }
 
+  compileArrayRegex(context: ResolvedPathContext, identifier: string, value: RegExp | string): { sql: string; formatted: unknown } {
+    const targetSqlPath = this.#getArraySqlPath(context);
+    const regex = value instanceof RegExp ? value : new RegExp(String(value));
+    const caseInsensitive = regex.flags.includes('i');
+    const regexOp = this.getRegexOperator(caseInsensitive);
+    const regexSource = this.formatRegex(regex.source, caseInsensitive);
+
+    return {
+      sql: `EXISTS (SELECT 1 FROM JSON_TABLE(${targetSqlPath}, '$[*]' COLUMNS (val VARCHAR(255) PATH '$')) AS jt WHERE jt.val ${regexOp} ${identifier})`,
+      formatted: regexSource
+    };
+  }
+
   compileJsonEquality(sqlPath: string, identifier: string): string {
     return `CAST(${sqlPath} AS JSON) = CAST(${identifier} AS JSON)`;
   }

--- a/module/model-postgres/src/dialect.ts
+++ b/module/model-postgres/src/dialect.ts
@@ -185,6 +185,31 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     return { sql: `(${target.jsonbPath} IS NOT NULL AND ${target.jsonbPath} <> '[]'::jsonb)` };
   }
 
+  compileArrayRegex(context: ResolvedPathContext, identifier: string, value: RegExp | string): { sql: string; formatted: unknown } {
+    const target = this.#getPostgresArrayTarget(context);
+    const regex = value instanceof RegExp ? value : new RegExp(String(value));
+    const caseInsensitive = regex.flags.includes('i');
+    const regexOp = this.getRegexOperator(caseInsensitive);
+    const regexSource = this.formatRegex(regex.source, caseInsensitive);
+
+    if (target.isNative) {
+      return {
+        sql: `EXISTS (SELECT 1 FROM unnest(${target.sqlPath}) AS elem WHERE elem ${regexOp} ${identifier})`,
+        formatted: regexSource
+      };
+    }
+
+    const subAccessor =
+      context.subPath && context.subPath.length > 0
+        ? `->${context.subPath.map(segment => `'${this.escapeLiteral(segment)}'`).join('->')}`
+        : '';
+
+    return {
+      sql: `EXISTS (SELECT 1 FROM jsonb_array_elements_text((${target.jsonbPath})${subAccessor}) AS elem WHERE elem ${regexOp} ${identifier})`,
+      formatted: regexSource
+    };
+  }
+
   getRegexOperator(caseInsensitive: boolean): string {
     return caseInsensitive ? '~*' : '~';
   }

--- a/module/model-query/src/util/suggest.ts
+++ b/module/model-query/src/util/suggest.ts
@@ -86,7 +86,7 @@ export class ModelQuerySuggestUtil {
 
     for (const result of results) {
       let resultValue = result[castKey<T>(parts[0])];
-      for (let i = 1; i < parts.length; i += 1) {
+      for (let i = 1; i < parts.length && resultValue !== undefined && resultValue !== null; i += 1) {
         resultValue = resultValue[castKey(parts[i])];
       }
       if (Array.isArray(resultValue)) {

--- a/module/model-query/support/test/suggest.ts
+++ b/module/model-query/support/test/suggest.ts
@@ -6,7 +6,7 @@ import { Suite, Test } from '@travetto/test';
 import { BaseModelSuite } from '@travetto/model/support/test/base.ts';
 
 import type { ModelQuerySuggestSupport } from '../../src/types/suggest.ts';
-import { Person } from './model.ts';
+import { Person, WithNestedLists, WithNestedNestedLists } from './model.ts';
 
 @Suite()
 export abstract class ModelQuerySuggestSuite extends BaseModelSuite<ModelQuerySuggestSupport & ModelCrudSupport> {
@@ -25,6 +25,23 @@ export abstract class ModelQuerySuggestSuite extends BaseModelSuite<ModelQuerySu
     );
 
     await this.saveAll(Person, people);
+  }
+
+  async #loadNestedLists() {
+    await this.saveAll(WithNestedLists, [
+      WithNestedLists.from({ tags: ['apple', 'banana', 'apricot'], names: ['alex', 'amber'] }),
+      WithNestedLists.from({ tags: ['blueberry', 'avocado'], names: ['bob', 'bill'] }),
+      WithNestedLists.from({ tags: ['cherry', 'date'], names: ['charlie'] })
+    ]);
+  }
+
+  async #loadNestedNestedLists() {
+    await this.saveAll(WithNestedNestedLists, [
+      WithNestedNestedLists.from({ tags: ['apple', 'banana'], sub: { names: ['alex', 'amber'] } }),
+      WithNestedNestedLists.from({ tags: ['blueberry'], sub: { names: ['avocado', 'bill'] } }),
+      WithNestedNestedLists.from({ tags: ['cherry'], sub: { names: ['charlie'] } }),
+      WithNestedNestedLists.from({ tags: ['date'] })
+    ]);
   }
 
   @Test('Verify value suggestion')
@@ -64,5 +81,40 @@ export abstract class ModelQuerySuggestSuite extends BaseModelSuite<ModelQuerySu
     assert(suggestedEntities[1].name === 'Bob');
     assert(suggestedEntities[0] instanceof Person);
     assert(suggestedEntities[1] instanceof Person);
+  }
+
+  @Test('Verify suggestion on string arrays')
+  async verifyStringArraySuggestions() {
+    const service = await this.service;
+
+    await this.#loadNestedLists();
+
+    const suggestedValues = await service.suggestValuesByQuery(WithNestedLists, 'tags', 'ap');
+    assert(suggestedValues.length === 2);
+    assert(suggestedValues[0] === 'apple');
+    assert(suggestedValues[1] === 'apricot');
+
+    const suggestedEntities = await service.suggestByQuery(WithNestedLists, 'tags', 'ap');
+    assert(suggestedEntities.length === 1);
+    assert(suggestedEntities[0] instanceof WithNestedLists);
+    assert(suggestedEntities[0].tags?.includes('apple'));
+  }
+
+  @Test('Verify suggestion on nested string arrays')
+  async verifyNestedStringArraySuggestions() {
+    const service = await this.service;
+
+    await this.#loadNestedNestedLists();
+
+    const suggestedValues = await service.suggestValuesByQuery(WithNestedNestedLists, 'sub.names', 'a');
+    assert(suggestedValues.length === 3);
+    assert(suggestedValues[0] === 'alex');
+    assert(suggestedValues[1] === 'amber');
+    assert(suggestedValues[2] === 'avocado');
+
+    const suggestedEntities = await service.suggestByQuery(WithNestedNestedLists, 'sub.names', 'al');
+    assert(suggestedEntities.length === 1);
+    assert(suggestedEntities[0] instanceof WithNestedNestedLists);
+    assert(suggestedEntities[0].sub?.names?.includes('alex'));
   }
 }

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -68,6 +68,7 @@ export abstract class AbstractANSI99Dialect {
   abstract compileArrayEquals(context: ResolvedPathContext, identifier: string, values: unknown): { sql: string; formatted: unknown };
   abstract compileArrayAny(context: ResolvedPathContext, identifier: string, values: unknown[]): { sql: string; formatted: unknown };
   abstract compileArrayExists(context: ResolvedPathContext, identifier?: string): { sql: string };
+  abstract compileArrayRegex(context: ResolvedPathContext, identifier: string, value: RegExp | string): { sql: string; formatted: unknown };
 
   abstract getRegexOperator(caseInsensitive: boolean): string;
   abstract formatRegex(source: string, caseInsensitive: boolean): string;
@@ -448,6 +449,9 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
           const { sql } = this.compileArrayExists(resolvedContext, identifier);
           const finalSql = !value ? `NOT(${sql})` : sql;
           clause = { sql: finalSql };
+        } else if (operator === '$regex') {
+          const { sql, formatted } = this.compileArrayRegex(resolvedContext, identifier, value as RegExp | string);
+          clause = { sql, parameters: { [identifier]: formatted } };
         } else {
           throw new RuntimeError(`Operator "${operator}" is not supported for arrays`, { category: 'data' });
         }

--- a/module/model-sql/support/test/query.ts
+++ b/module/model-sql/support/test/query.ts
@@ -66,6 +66,10 @@ class MockDialect extends AbstractANSI99Dialect {
     return { sql: `${context.sqlPath} IS NOT NULL`, formatted: undefined };
   }
 
+  compileArrayRegex(context: ResolvedPathContext, identifier: string, value: RegExp | string) {
+    return { sql: `${context.sqlPath} REGEX ${identifier}`, formatted: value };
+  }
+
   getRegexOperator(caseInsensitive: boolean) {
     return caseInsensitive ? '~*' : '~';
   }

--- a/module/model-sqlite/src/dialect.ts
+++ b/module/model-sqlite/src/dialect.ts
@@ -163,6 +163,17 @@ NOT EXISTS (
     return { sql: `(${jsonArrayExpression} IS NOT NULL AND json_array_length(${jsonArrayExpression}) > 0)` };
   }
 
+  compileArrayRegex(context: ResolvedPathContext, identifier: string, value: RegExp | string): { sql: string; formatted: unknown } {
+    const regex = value instanceof RegExp ? value : new RegExp(String(value));
+    const caseInsensitive = regex.flags.includes('i');
+    const regexOp = this.getRegexOperator(caseInsensitive);
+    const regexSource = this.formatRegex(regex.source, caseInsensitive);
+    return {
+      sql: this.#buildArrayElementExists(context, leafExpression => `${leafExpression} ${regexOp} ${identifier}`),
+      formatted: regexSource
+    };
+  }
+
   getRegexOperator(caseInsensitive: boolean): string {
     return 'REGEXP';
   }

--- a/module/runtime/src/types.ts
+++ b/module/runtime/src/types.ts
@@ -33,19 +33,21 @@ export type ValidFields<T, I> = {
 
 export type RetainIntrinsicFields<T> = Pick<T, ValidFields<T, IntrinsicType>>;
 
-export type KeyPaths<T, PrimitiveType = IntrinsicType | IntrinsicType[], PREFIX extends string = '', SEP extends string = '.'> = {
+type KeyPathsInner<T, PrimitiveType = IntrinsicType | IntrinsicType[], PREFIX extends string = '', SEP extends string = '.'> = {
   [K in keyof T]: K extends string
     ? T[K] extends IntrinsicType[] | IntrinsicType | undefined
       ? T[K] extends PrimitiveType
         ? `${PREFIX}${K}`
         : never
       : T[K] extends Any[]
-        ? KeyPaths<T[K][number], PrimitiveType, `${K}${SEP}`, SEP>
+        ? KeyPathsInner<T[K][number], PrimitiveType, `${K}${SEP}`, SEP>
         : T[K] extends object
-          ? KeyPaths<T[K], PrimitiveType, `${K}${SEP}`, SEP>
+          ? KeyPathsInner<T[K], PrimitiveType, `${K}${SEP}`, SEP>
           : never
     : never;
 }[keyof T];
+
+export type KeyPaths<T, PrimitiveType = IntrinsicType | IntrinsicType[]> = KeyPathsInner<Required<T>, PrimitiveType>;
 
 export const TypedObject: {
   keys<T = unknown, K extends keyof T = keyof T & string>(value: T): K[];


### PR DESCRIPTION
## Overview
This PR adds support for `$regex` queries on array fields across model query implementations and SQL dialects (`MySQL`, `PostgreSQL`, `SQLite`), along with improving string array suggestions.

## Changes Included
- **Runtime KeyPaths**: Updated `KeyPaths` type utility in `@travetto/runtime` to properly resolve key paths through optional and nested properties using `Required<T>`.
- **SQL Dialects (`model-sql`, `model-mysql`, `model-postgres`, `model-sqlite`)**:
  - Implemented `compileArrayRegex` across ANSI SQL dialects to support `$regex` queries on array elements (via `JSON_TABLE` in MySQL, `unnest`/`jsonb_array_elements_text` in PostgreSQL, and array expression matchers in SQLite).
- **Elasticsearch Query (`model-elasticsearch`)**:
  - Refined regex query generation for array and non-text fields.
- **Model Query Suggestions (`model-query`)**:
  - Added safe property traversal in `suggestValuesByQuery` to avoid potential `null`/`undefined` errors.
  - Added test suites for string array and nested string array value and entity suggestions.