### PR TITLE
fix(model-sql): refactor SQL dialects for index matching, diffing, and parity

### DIFF
--- a/module/model-mysql/src/dialect.ts
+++ b/module/model-mysql/src/dialect.ts
@@ -1,6 +1,6 @@
 import { AbstractANSI99Dialect, type JSONSqlPathMode, type ResolvedPathContext, type TableContext } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil } from '@travetto/runtime';
-import { type SchemaFieldConfig, SchemaRegistryIndex } from '@travetto/schema';
+import type { SchemaFieldConfig } from '@travetto/schema';
 
 export class MysqlDialect extends AbstractANSI99Dialect {
   override returningSupport = false;
@@ -54,36 +54,15 @@ export class MysqlDialect extends AbstractANSI99Dialect {
   }
 
   compileJsonIndexPath(columnName: string, jsonPath: string[], mode: JSONSqlPathMode): string {
-    const result = `${columnName}->>'$.${jsonPath.join('.')}'`;
-    switch (mode) {
-      case 'createIndex':
-        return `(CAST(${result} as CHAR(255)) COLLATE utf8mb4_bin)`;
-      case 'orderBy':
-      case 'read':
-        return result;
-    }
+    return `${columnName}->>'$.${this.formatJsonPath(jsonPath)}'`;
   }
 
   #formatSubPath(context: ResolvedPathContext): string {
     if (!context.subPath || context.subPath.length === 0) {
       return '';
     }
-    let currentClass: Class | undefined = context.arrayField?.type;
-    const parts: string[] = [];
-    for (let index = 0; index < context.subPath.length; index++) {
-      const segment = context.subPath[index];
-      if (currentClass) {
-        const classConfig = SchemaRegistryIndex.getOptional(currentClass)?.get();
-        const fieldConfig = classConfig?.fields[segment];
-        if (fieldConfig) {
-          parts.push(fieldConfig.array ? `${segment}[*]` : segment);
-          currentClass = fieldConfig.type;
-          continue;
-        }
-      }
-      parts.push(segment);
-    }
-    return parts.join('.');
+    const subPathMetadata = this.getSchemaSubPathMetadata(context.arrayField?.type, context.subPath);
+    return subPathMetadata.map(({ segment, isArray }) => (isArray ? `${segment}[*]` : segment)).join('.');
   }
 
   #getArraySqlPath(context: ResolvedPathContext): string {
@@ -150,6 +129,8 @@ export class MysqlDialect extends AbstractANSI99Dialect {
       return `CAST(${sqlPath} AS SIGNED)`;
     } else if (type === Date) {
       return `CAST(${sqlPath} AS DATETIME(6))`;
+    } else if (type === String) {
+      return `(CAST(${sqlPath} AS CHAR(255)) COLLATE utf8mb4_bin)`;
     }
     return sqlPath;
   }
@@ -161,13 +142,8 @@ export class MysqlDialect extends AbstractANSI99Dialect {
     conflictTarget: string[],
     updates: string[]
   ): string {
-    const mysqlUpdates = updates.map(val => val.replace(/EXCLUDED\.(.*)/g, 'VALUES($1)'));
-    return `
-INSERT INTO 
-  ${this.escapeIdentifier(context.tableName)} (${columns.join(', ')}) 
-VALUES 
-  (${placeholders.join(', ')}) 
-ON DUPLICATE KEY UPDATE ${mysqlUpdates.join(', ')};`;
+    const mysqlUpdateStatements = updates.map(statement => statement.replaceAll(/EXCLUDED\.(.*)/g, 'new_row.$1'));
+    return `INSERT INTO ${this.escapeIdentifier(context.tableName)} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) AS new_row ON DUPLICATE KEY UPDATE ${mysqlUpdateStatements.join(', ')};`;
   }
 
   getTableExistsQuery(context: TableContext): { sql: string; parameters?: unknown[] } {
@@ -191,7 +167,7 @@ WHERE table_schema = ? AND table_name = ?;
       sql: `
 SELECT 
   COLUMN_NAME as name, 
-  DATA_TYPE as type 
+  COLUMN_TYPE as type 
 FROM information_schema.columns 
 WHERE table_schema = ? AND table_name = ?;
 `,
@@ -206,23 +182,47 @@ WHERE table_schema = ? AND table_name = ?;
   getExistingIndexesQuery(context: TableContext): { sql: string; parameters?: unknown[] } {
     return {
       sql: `
-SELECT DISTINCT 
-  INDEX_NAME as name 
+SELECT 
+  INDEX_NAME as name,
+  TABLE_NAME as tableName,
+  NON_UNIQUE as nonUnique,
+  GROUP_CONCAT(COALESCE(EXPRESSION, COLUMN_NAME) ORDER BY SEQ_IN_INDEX SEPARATOR ', ') as indexColumns
 FROM information_schema.statistics 
 WHERE 
   table_schema = ? 
   AND table_name = ? 
-  AND INDEX_NAME != 'PRIMARY';
+  AND INDEX_NAME != 'PRIMARY'
+GROUP BY INDEX_NAME, TABLE_NAME, NON_UNIQUE;
 `,
       parameters: [context.database, context.tableName]
     };
   }
 
   parseExistingIndexes(records: unknown[]): Map<string, string> {
-    return new Map(castTo<{ name: string }[]>(records).map(record => [record.name, '']));
+    return new Map(
+      castTo<{ name: string; tableName: string; nonUnique: number; indexColumns: string }[]>(records).map(record => {
+        const isUnique = Number(record.nonUnique) === 0;
+        const indexDefinition = `CREATE ${isUnique ? 'UNIQUE ' : ''}INDEX ${this.escapeIdentifier(record.name)} ON ${this.escapeIdentifier(record.tableName)} (${record.indexColumns});`;
+        return [record.name, indexDefinition];
+      })
+    );
   }
 
   override getDropIndexSQL(context: TableContext, indexName: string): string {
     return `DROP INDEX ${this.escapeIdentifier(indexName)} ON ${this.escapeIdentifier(context.tableName)};`;
+  }
+
+  override getTruncateTableSQL(context: TableContext): string {
+    return `TRUNCATE TABLE ${this.escapeIdentifier(context.tableName)};`;
+  }
+
+  override getAlterColumnTypeSQL(context: TableContext, columnName: string, columnType: string, existingType: string): string | undefined {
+    const normalizedExisting = existingType.replaceAll('CHARACTER VARYING', 'VARCHAR').replaceAll('INTEGER', 'INT');
+    const normalizedRequested = columnType.toUpperCase().replaceAll('CHARACTER VARYING', 'VARCHAR').replaceAll('INTEGER', 'INT');
+
+    if (!normalizedExisting.startsWith(normalizedRequested) && !normalizedRequested.startsWith(normalizedExisting)) {
+      return `ALTER TABLE ${this.escapeIdentifier(context.tableName)} MODIFY COLUMN ${this.escapeIdentifier(columnName)} ${columnType};`;
+    }
+    return undefined;
   }
 }

--- a/module/model-postgres/src/dialect.ts
+++ b/module/model-postgres/src/dialect.ts
@@ -74,29 +74,23 @@ export class PostgresDialect extends AbstractANSI99Dialect {
     return `$${index}`;
   }
 
+  override getUpsertSQL(
+    context: TableContext,
+    columns: string[],
+    placeholders: string[],
+    conflictTarget: string[],
+    updates: string[]
+  ): string {
+    return `INSERT INTO ${this.escapeIdentifier(context.tableName)} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) ON CONFLICT (${conflictTarget.join(', ')}) DO UPDATE SET ${updates.join(', ')} RETURNING *;`;
+  }
+
   #buildContainmentPayload(value: unknown, context: ResolvedPathContext): unknown {
     if (!context.subPath || context.subPath.length === 0) {
       return Array.isArray(value) ? value : [value];
     }
 
-    const isArraySegment = new Array<boolean>(context.subPath.length).fill(false);
-    let currentClass: Class | undefined = context.arrayField?.type;
-    for (let index = 0; index < context.subPath.length; index++) {
-      if (!currentClass) {
-        break;
-      }
-      const segment = context.subPath[index];
-      const classConfig = SchemaRegistryIndex.getOptional(currentClass)?.get();
-      const fieldConfig = classConfig?.fields[segment];
-      if (fieldConfig) {
-        if (fieldConfig.array) {
-          isArraySegment[index] = true;
-        }
-        currentClass = fieldConfig.type;
-      } else {
-        break;
-      }
-    }
+    const subPathMetadata = this.getSchemaSubPathMetadata(context.arrayField?.type, context.subPath);
+    const isArraySegment = subPathMetadata.map(item => item.isArray);
 
     const buildPayloadForValue = (item: unknown): unknown => {
       let itemPayload: unknown = item;

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -99,8 +99,12 @@ export abstract class AbstractANSI99Dialect {
     }
   }
 
+  formatJsonPath(jsonPath: string[]): string {
+    return jsonPath.map(segment => `"${segment.replaceAll('"', '\\"')}"`).join('.');
+  }
+
   compileIndexPath(context: TableContext, path: string[], mode: JSONSqlPathMode): string {
-    return this.buildSqlPath(context, path, mode);
+    return this.resolvePath(context, path, mode).sqlPath;
   }
 
   getCreateIndexSQL(context: TableContext, indexConfig: IndexConfig): string {
@@ -165,15 +169,20 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     return `ALTER TABLE ${this.escapeIdentifier(context.tableName)} ADD COLUMN ${this.escapeIdentifier(columnName)} ${columnType};`;
   }
 
-  getUpsertSQL(context: TableContext, columns: string[], placeholders: string[], conflictTarget: string[], updates: string[]): string {
-    return `INSERT INTO ${this.escapeIdentifier(context.tableName)} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) ON CONFLICT (${conflictTarget.join(', ')}) DO UPDATE SET ${updates.join(', ')} RETURNING *;`;
-  }
+  abstract getUpsertSQL(
+    context: TableContext,
+    columns: string[],
+    placeholders: string[],
+    conflictTarget: string[],
+    updates: string[]
+  ): string;
 
   normalizeIndexDefinition(sql: string): string {
     return sql
       .toLowerCase()
       .replaceAll('"', '')
       .replaceAll("'", '')
+      .replaceAll('`', '')
       .replaceAll(' ', '')
       .replaceAll('asc', '')
       .replaceAll('desc', '')
@@ -190,17 +199,11 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
   abstract parseExistingColumns(records: unknown[]): Map<string, string>;
   abstract getExistingIndexesQuery(context: TableContext): { sql: string; parameters?: unknown[] };
   abstract parseExistingIndexes(records: unknown[]): Map<string, string>;
-
-  getDropIndexSQL(context: TableContext, indexName: string): string {
-    return `DROP INDEX ${this.escapeIdentifier(indexName)} ON ${this.escapeIdentifier(context.tableName)};`;
-  }
+  abstract getDropIndexSQL(context: TableContext, indexName: string): string;
+  abstract getTruncateTableSQL(context: TableContext): string;
 
   getDropTableSQL(context: TableContext): string {
     return `DROP TABLE IF EXISTS ${this.escapeIdentifier(context.tableName)};`;
-  }
-
-  getTruncateTableSQL(context: TableContext): string {
-    return `TRUNCATE TABLE ${this.escapeIdentifier(context.tableName)};`;
   }
 
   getAlterColumnTypeSQL?(context: TableContext, columnName: string, columnType: string, existingType: string): string | undefined;
@@ -307,6 +310,28 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
       arrayField,
       arraySegmentIndex
     };
+  }
+
+  getSchemaSubPathMetadata(
+    initialClass: Class | undefined,
+    subPath: string[]
+  ): Array<{ segment: string; fieldConfig?: SchemaFieldConfig; isArray: boolean; fieldClass?: Class }> {
+    let currentClass = initialClass;
+    return subPath.map(segment => {
+      let fieldConfig: SchemaFieldConfig | undefined;
+      let isArray = false;
+      if (currentClass) {
+        const classConfiguration = SchemaRegistryIndex.getOptional(currentClass)?.get();
+        fieldConfig = classConfiguration?.fields[segment];
+        if (fieldConfig) {
+          isArray = !!fieldConfig.array;
+          currentClass = fieldConfig.type;
+        } else {
+          currentClass = undefined;
+        }
+      }
+      return { segment, fieldConfig, isArray, fieldClass: currentClass };
+    });
   }
 
   resolvePath<T extends ModelType>(tableContext: TableContext<T>, path: string[], mode: JSONSqlPathMode): ResolvedPathContext {
@@ -670,23 +695,7 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
     return { sql, values };
   }
 
-  compilePartialUpdate<T extends ModelType>(
-    tableContext: TableContext<T>,
-    preparedData: Partial<T>
-  ): { sets: string[]; values: unknown[] } {
-    const { sql, values } = this.buildPartialUpdate(tableContext, preparedData);
-    const setMatch = sql.match(/SET (.*?)(\s+WHERE|$)/);
-    const sets = setMatch ? setMatch[1].split(', ') : [];
-    return { sets, values };
-  }
-
-  buildPartialUpdate<T extends ModelType>(
-    tableContext: TableContext<T>,
-    preparedData: Partial<T>,
-    whereSQL?: string,
-    whereParameters: unknown[] = [],
-    returning = false
-  ): { sql: string; values: unknown[] } {
+  #buildUpdateSets<T extends ModelType>(tableContext: TableContext<T>, preparedData: Partial<T>): { sets: string[]; values: unknown[] } {
     const sets: string[] = [];
     const values: unknown[] = [];
 
@@ -704,6 +713,25 @@ CREATE TABLE ${this.escapeIdentifier(context.tableName)} (
         values.push(this.getComplexColumnValue(complexField, value));
       }
     }
+
+    return { sets, values };
+  }
+
+  compilePartialUpdate<T extends ModelType>(
+    tableContext: TableContext<T>,
+    preparedData: Partial<T>
+  ): { sets: string[]; values: unknown[] } {
+    return this.#buildUpdateSets(tableContext, preparedData);
+  }
+
+  buildPartialUpdate<T extends ModelType>(
+    tableContext: TableContext<T>,
+    preparedData: Partial<T>,
+    whereSQL?: string,
+    whereParameters: unknown[] = [],
+    returning = false
+  ): { sql: string; values: unknown[] } {
+    const { sets, values } = this.#buildUpdateSets(tableContext, preparedData);
 
     const shiftedWhereSQL = whereSQL && this.shiftPlaceholders ? this.shiftPlaceholders(whereSQL, values.length) : whereSQL;
     if (whereSQL) {

--- a/module/model-sql/src/dialect.ts
+++ b/module/model-sql/src/dialect.ts
@@ -100,7 +100,7 @@ export abstract class AbstractANSI99Dialect {
   }
 
   formatJsonPath(jsonPath: string[]): string {
-    return jsonPath.map(segment => `"${segment.replaceAll('"', '\\"')}"`).join('.');
+    return jsonPath.map(segment => (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(segment) ? segment : `"${segment.replaceAll('"', '\\"')}"`)).join('.');
   }
 
   compileIndexPath(context: TableContext, path: string[], mode: JSONSqlPathMode): string {
@@ -119,7 +119,8 @@ export abstract class AbstractANSI99Dialect {
 
         const path = fieldKey.split('.');
         const expression = this.compileIndexPath(context, path, 'createIndex');
-        return `${expression} ${isAscending ? 'ASC' : 'DESC'}`;
+        const formattedExpression = path.length > 1 ? `(${expression})` : expression;
+        return `${formattedExpression} ${isAscending ? 'ASC' : 'DESC'}`;
       });
 
       return `CREATE ${indexConfig.unique ? 'UNIQUE ' : ''}INDEX ${this.escapeIdentifier(indexName)} ON ${this.escapeIdentifier(context.tableName)} (${indexFields.join(', ')});`;
@@ -127,7 +128,8 @@ export abstract class AbstractANSI99Dialect {
       const allFields = [...indexConfig.keyTemplate, ...indexConfig.sortTemplate];
       const indexFields = allFields.map(({ path, value }) => {
         const expression = this.compileIndexPath(context, path, 'createIndex');
-        return `${expression} ${value === -1 ? 'DESC' : 'ASC'}`;
+        const formattedExpression = path.length > 1 ? `(${expression})` : expression;
+        return `${formattedExpression} ${value === -1 ? 'DESC' : 'ASC'}`;
       });
 
       const isUnique = 'unique' in indexConfig && indexConfig.unique;

--- a/module/model-sql/support/test/dialect.ts
+++ b/module/model-sql/support/test/dialect.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert';
+
+import { Model, type ModelType } from '@travetto/model';
+import { Registry } from '@travetto/registry';
+import type { Class } from '@travetto/runtime';
+import { Schema } from '@travetto/schema';
+import { BeforeAll, Suite, Test } from '@travetto/test';
+
+import { MysqlDialect } from '../../../model-mysql/src/dialect.ts';
+import { PostgresDialect } from '../../../model-postgres/src/dialect.ts';
+import { SqliteDialect } from '../../../model-sqlite/src/dialect.ts';
+import { SQLModelSchemaUtil } from '../../src/schema.ts';
+import type { TableContext } from '../../src/types.ts';
+
+@Schema()
+class ChildItem {
+  name: string;
+  age: number;
+  active: boolean;
+  createdDate: Date;
+}
+
+@Model()
+class ParentModel {
+  id: string;
+  title: string;
+  child: ChildItem;
+}
+
+function getTableContext<T extends ModelType>(modelClass: Class<T>): TableContext<T> {
+  return {
+    tableName: modelClass.name.toLowerCase(),
+    ...SQLModelSchemaUtil.getSchemaContext(modelClass)
+  };
+}
+
+@Suite()
+export class SQLDialectGapsTest {
+  @BeforeAll()
+  async setup() {
+    await Registry.init();
+  }
+
+  @Test()
+  async testIndexAndQueryExpressionParity() {
+    const tableContext = getTableContext(ParentModel);
+    const mysqlDialect = new MysqlDialect();
+    const postgresDialect = new PostgresDialect();
+    const sqliteDialect = new SqliteDialect();
+
+    // Verify MySQL path resolution matches index creation
+    const mysqlAgeResolved = mysqlDialect.resolvePath(tableContext, ['child', 'age'], 'read');
+    assert(mysqlAgeResolved.sqlPath === "CAST(`child`->>'$.age' AS DECIMAL)");
+
+    const mysqlNameResolved = mysqlDialect.resolvePath(tableContext, ['child', 'name'], 'read');
+    assert(mysqlNameResolved.sqlPath === "(CAST(`child`->>'$.name' AS CHAR(255)) COLLATE utf8mb4_bin)");
+
+    // Verify Postgres path resolution matches index creation
+    const postgresAgeResolved = postgresDialect.resolvePath(tableContext, ['child', 'age'], 'read');
+    assert(postgresAgeResolved.sqlPath === '((("child"->>\'age\')))::NUMERIC');
+
+    // Verify SQLite path resolution matches index creation
+    const sqliteAgeResolved = sqliteDialect.resolvePath(tableContext, ['child', 'age'], 'read');
+    assert(sqliteAgeResolved.sqlPath === 'CAST(json_extract("child", \'$.age\') AS NUMERIC)');
+  }
+
+  @Test()
+  async testSqliteArraySubObjectPatch() {
+    const tableContext = getTableContext(ParentModel);
+    const sqliteDialect = new SqliteDialect();
+
+    const resolvedContext = sqliteDialect.resolvePath(tableContext, ['child', 'name'], 'read');
+    const { sql } = sqliteDialect.compileArrayEquals(resolvedContext, '$$1', { name: 'bob' });
+
+    assert(sql.includes('json_patch('));
+    assert(sql.includes('= elem.value'));
+  }
+
+  @Test()
+  async testCreateIndexes() {
+    const tableContext = getTableContext(ParentModel);
+    const mysqlDialect = new MysqlDialect();
+    const postgresDialect = new PostgresDialect();
+
+    // Verify create index SQL contains the resolved expressions
+    const mysqlCreateIndexSql = mysqlDialect.getCreateIndexSQL(tableContext, {
+      type: 'query',
+      name: 'child_age',
+      fields: [{ 'child.age': 1 }]
+    });
+    assert(mysqlCreateIndexSql.includes("(CAST(`child`->>'$.age' AS DECIMAL))"));
+
+    const postgresCreateIndexSql = postgresDialect.getCreateIndexSQL(tableContext, {
+      type: 'query',
+      name: 'child_age',
+      fields: [{ 'child.age': 1 }]
+    });
+    assert(postgresCreateIndexSql.includes('((("child"->>\'age\')))::NUMERIC)'));
+  }
+
+  @Test()
+  async testMysqlExistingIndexesParsing() {
+    const mysqlDialect = new MysqlDialect();
+    const existingIndexRecords = [
+      {
+        name: 'idx_parentmodel_child_age',
+        tableName: 'parentmodel',
+        nonUnique: 1,
+        indexColumns: "(CAST(`child`->>'$.age' AS DECIMAL))"
+      }
+    ];
+
+    const parsedIndexes = mysqlDialect.parseExistingIndexes(existingIndexRecords);
+    assert(parsedIndexes.size === 1);
+    assert(parsedIndexes.has('idx_parentmodel_child_age'));
+
+    const indexDefinition = parsedIndexes.get('idx_parentmodel_child_age')!;
+    assert(indexDefinition.includes('CREATE INDEX `idx_parentmodel_child_age` ON `parentmodel`'));
+    assert(indexDefinition.includes("(CAST(`child`->>'$.age' AS DECIMAL))"));
+
+    const normalizedDefinition = mysqlDialect.normalizeIndexDefinition(indexDefinition);
+    assert(normalizedDefinition.length > 0);
+  }
+
+  @Test()
+  async testMysqlAlterColumnType() {
+    const tableContext = getTableContext(ParentModel);
+    const mysqlDialect = new MysqlDialect();
+
+    const alterColumnSql = mysqlDialect.getAlterColumnTypeSQL(tableContext, 'title', 'VARCHAR(255)', 'INT');
+    assert(alterColumnSql === 'ALTER TABLE `parentmodel` MODIFY COLUMN `title` VARCHAR(255);');
+
+    const noopAlterColumnSql = mysqlDialect.getAlterColumnTypeSQL(tableContext, 'title', 'VARCHAR(255)', 'VARCHAR(255)');
+    assert(noopAlterColumnSql === undefined);
+  }
+
+  @Test()
+  async testFormatJsonPathEscaping() {
+    const mysqlDialect = new MysqlDialect();
+
+    const simpleJsonPath = mysqlDialect.formatJsonPath(['child', 'age']);
+    assert(simpleJsonPath === 'child.age');
+
+    const complexJsonPath = mysqlDialect.formatJsonPath(['child', 'first name']);
+    assert(complexJsonPath === 'child."first name"');
+  }
+
+  @Test()
+  async testPartialUpdateSetsWithoutRegex() {
+    const tableContext = getTableContext(ParentModel);
+    const sqliteDialect = new SqliteDialect();
+
+    const { sets, values } = sqliteDialect.compilePartialUpdate(tableContext, { title: 'Updated Title' });
+    assert.deepStrictEqual(sets, ['"title" = ?']);
+    assert.deepStrictEqual(values, ['Updated Title']);
+  }
+}

--- a/module/model-sqlite/src/dialect.ts
+++ b/module/model-sqlite/src/dialect.ts
@@ -1,6 +1,6 @@
 import { AbstractANSI99Dialect, type ResolvedPathContext, type TableContext, type TransactionStatements } from '@travetto/model-sql';
 import { type Class, castTo, JSONUtil } from '@travetto/runtime';
-import { type SchemaFieldConfig, SchemaRegistryIndex } from '@travetto/schema';
+import type { SchemaFieldConfig } from '@travetto/schema';
 
 export class SqliteDialect extends AbstractANSI99Dialect {
   returningSupport = true;
@@ -8,6 +8,16 @@ export class SqliteDialect extends AbstractANSI99Dialect {
     ...AbstractANSI99Dialect.TRANSACTION_STATEMENTS,
     begin: 'BEGIN IMMEDIATE;'
   };
+
+  override getUpsertSQL(
+    context: TableContext,
+    columns: string[],
+    placeholders: string[],
+    conflictTarget: string[],
+    updates: string[]
+  ): string {
+    return `INSERT INTO ${this.escapeIdentifier(context.tableName)} (${columns.join(', ')}) VALUES (${placeholders.join(', ')}) ON CONFLICT (${conflictTarget.join(', ')}) DO UPDATE SET ${updates.join(', ')} RETURNING *;`;
+  }
 
   getComplexColumnType(field: SchemaFieldConfig): string {
     return 'TEXT';
@@ -38,7 +48,7 @@ export class SqliteDialect extends AbstractANSI99Dialect {
   }
 
   compileJsonIndexPath(columnName: string, jsonPath: string[]): string {
-    return `json_extract(${columnName}, '$.${jsonPath.join('.')}')`;
+    return `json_extract(${columnName}, '$.${this.formatJsonPath(jsonPath)}')`;
   }
 
   #getSqliteArrayExpression(context: ResolvedPathContext): string {
@@ -55,22 +65,10 @@ export class SqliteDialect extends AbstractANSI99Dialect {
       return onLeaf(parentExpression);
     }
 
-    const arraySegmentIndices: number[] = [];
-    let currentClass: Class | undefined = context.arrayField?.type;
-
-    for (let index = 0; index < context.subPath.length; index++) {
-      const segment = context.subPath[index];
-      if (currentClass) {
-        const classConfiguration = SchemaRegistryIndex.getOptional(currentClass)?.get();
-        const fieldConfiguration = classConfiguration?.fields[segment];
-        if (fieldConfiguration) {
-          if (fieldConfiguration.array) {
-            arraySegmentIndices.push(index);
-          }
-          currentClass = fieldConfiguration.type;
-        }
-      }
-    }
+    const subPathMetadata = this.getSchemaSubPathMetadata(context.arrayField?.type, context.subPath);
+    const arraySegmentIndices = subPathMetadata
+      .map((metadataItem, metadataIndex) => (metadataItem.isArray ? metadataIndex : -1))
+      .filter(itemIndex => itemIndex !== -1);
 
     if (arraySegmentIndices.length === 0) {
       const leafExpression = `json_extract(${parentExpression}, '$.${context.subPath.join('.')}')`;
@@ -135,15 +133,7 @@ EXISTS (
 
     if (typeof values === 'object' && values !== null) {
       return {
-        sql: this.#buildArrayElementExists(
-          context,
-          leafExpression => `
-NOT EXISTS (
-  SELECT 1 
-  FROM json_each(${identifier}) AS req 
-  WHERE json_extract(${leafExpression}, '$.' || req.key) IS NOT req.value
-)`
-        ),
+        sql: this.#buildArrayElementExists(context, leafExpression => `json_patch(${leafExpression}, ${identifier}) = ${leafExpression}`),
         formatted: JSONUtil.toUTF8(values)
       };
     }


### PR DESCRIPTION
## Summary of Changes

1. **Index Creation vs. Query Predicate Expression Alignment**
   - Refactored `compileIndexPath` in `AbstractANSI99Dialect` to route through `resolvePath(context, path, mode)`, ensuring `castColumn(sqlPath, leafField.type)` is consistently applied for both index generation and query predicate resolution across all field types and dialects.
   - Updated `MysqlDialect` `castColumn` to support `String` casting (`(CAST(... AS CHAR(255)) COLLATE utf8mb4_bin)`), ensuring query predicates match generated functional index expressions exactly.

2. **MySQL Index-Diffing Fix**
   - Updated `MysqlDialect.getExistingIndexesQuery` and `parseExistingIndexes` to query `information_schema.statistics` with `GROUP_CONCAT` over column/expression sequences, constructing fully diffable `CREATE [UNIQUE] INDEX ...` strings.

3. **Standardized JSON Path Escaping**
   - Added `formatJsonPath(jsonPath: string[])` in `AbstractANSI99Dialect` to double-quote and escape JSON path segments across SQLite and MySQL extractions.

4. **Nested-Object Array Containment Parity**
   - Updated `SqliteDialect.compileArrayEquals` to use `json_patch(leafExpression, identifier) = leafExpression`, achieving recursive sub-document containment parity with Postgres (`@>`) and MySQL (`JSON_CONTAINS`).

5. **Base Class Abstract Contract Enforcement**
   - Declared `getUpsertSQL`, `getDropIndexSQL`, and `getTruncateTableSQL` as `abstract` in `AbstractANSI99Dialect`, eliminating misleading base class defaults and forcing concrete dialect commitments.

6. **Maintenance & Modernization**
   - Added `getAlterColumnTypeSQL` to `MysqlDialect` using `MODIFY COLUMN`.
   - Updated `MysqlDialect` column schema lookup to select `COLUMN_TYPE` instead of `DATA_TYPE` to preserve length/precision.
   - Updated `MysqlDialect.getUpsertSQL` to MySQL 8.0.20+ row alias syntax (`AS new_row ON DUPLICATE KEY UPDATE`).
   - Refactored `compilePartialUpdate` in `AbstractANSI99Dialect` to eliminate regex parsing of generated SQL strings.
   - Added `getSchemaSubPathMetadata` helper to `AbstractANSI99Dialect` and consolidated redundant schema-walking sub-path logic across all 3 dialect implementations.